### PR TITLE
Increase number of seeds. Total time is now 45 minutes.

### DIFF
--- a/src/simulation/main_specification.py
+++ b/src/simulation/main_specification.py
@@ -89,11 +89,11 @@ def build_main_scenarios(base_path):
         n_seeds = 20
     elif FAST_FLAG == "verify":
         # with the verify fast flag only base scenario is run for the fall
-        # -> 10 * 2 + 3 * 3 = 29
+        # -> 21 * 2 + 3 * 6 = 60
         if "base" in base_path.name:
-            n_seeds = 15
+            n_seeds = 21
         else:
-            n_seeds = 10
+            n_seeds = 6
     else:
         raise ValueError(
             f"Unknown FAST_FLAG: {FAST_FLAG}. Must be one of 'debug', 'verify', 'full'."


### PR DESCRIPTION
The increased number of seeds will give us more certainty that the results remain unchanged when seeds change due to code changes. Given the speed up the runtime increase the time increase is acceptable. 

Results (note how the mean has changed): 

![image](https://user-images.githubusercontent.com/9567321/115222798-679d3400-a10b-11eb-9f63-bad63d78f4bc.png)
