### PR TITLE
Fade in Rapid Tests in the Educ Sector

### DIFF
--- a/src/create_initial_states/task_build_full_params.py
+++ b/src/create_initial_states/task_build_full_params.py
@@ -118,6 +118,8 @@ def task_create_full_params(depends_on, produces):
     params.loc[(*offer_loc, "2021-04-15"), "value"] = 0.7
     params.loc[(*offer_loc, "2021-06-15"), "value"] = 0.7
 
+    params = _add_educ_rapid_test_fade_in_params(params)
+
     # seasonality parameter
     params.loc[("seasonality_effect", "seasonality_effect", "seasonality_effect")] = 0.2
 
@@ -176,6 +178,67 @@ def _build_reaction_params(contact_models):
             else:
                 df.loc[(cm, name, name)] = multiplier
     return df
+
+
+def _add_educ_rapid_test_fade_in_params(params):
+    """Add the shares how many people with educ contacts get a rapid test.
+
+    Sources:
+        17-24 of March 2021 (Mon, 2021-03-22):
+            - NRW had 80% tests for students before Easter (https://bit.ly/3u7z8Rx)
+            - BY: test offers to educ_workers (https://bit.ly/3tbVX5u)
+            - BW: only tests for educ workers (https://bit.ly/2S7251M)
+
+            - federal level:
+                "In Kitas und Schulen sollen die Testmöglichkeiten "mit der
+                steigenden Verfügbarkeit von Schnell- und Selbsttests"
+                ausgebaut werden" (https://bit.ly/3nuCSKi)
+            - Some KiTa workers are being tested (https://bit.ly/3nyGyus)
+            - Self tests for students in Berlin (https://bit.ly/2ScGu8m)
+            - Schleswig-Holstein: test offer (https://bit.ly/3eVfkuv)
+            - mandatory tests in Saxony (https://bit.ly/3eEQGhn)
+            - no tests yet for students in Hessia, but already ordered
+              (https://bit.ly/3gMGJB4)
+            - Niedersachsen had one test week before Easter (https://bit.ly/3gOOC96)
+
+            => assume 90% of teachers and 30% of students do rapid tests
+
+        After Easter (2021-04-07):
+            - NRW: tests are mandatory for all
+            - Bavaria: tests are mandatory for all (https://bit.ly/3nz5fXS,
+              https://bit.ly/2QHilX3)
+            - BW: voluntary tests for students (https://bit.ly/3vuetaD)
+            - Brandenburg starts with tests (https://bit.ly/3xAihZB)
+            - Schleswig-Holstein: mandatory tests (https://bit.ly/3eVfkuv)
+
+            => assume 95% of teachers and 75% of students get tested
+
+        - BW: tests mandatory starting 2021-04-19 (https://bit.ly/3vuetaD)
+
+            => assume 95% of teachers and 95% of students get tested
+
+    """
+    params = params.copy(deep=True)
+
+    loc = ("rapid_test_demand", "educ_worker_shares")
+    params.loc[(*loc, "2020-01-01")] = 0.0
+    params.loc[(*loc, "2021-01-01")] = 0.0
+    # this is arbitrary to have a more convex shape
+    params.loc[(*loc, "2021-03-01")] = 0.3
+    params.loc[(*loc, "2021-03-22")] = 0.9
+    params.loc[(*loc, "2021-04-07")] = 0.95
+    params.loc[(*loc, "2021-04-19")] = 0.95
+    params.loc[(*loc, "2021-06-01")] = 0.95
+
+    loc = ("rapid_test_demand", "student_shares")
+    params.loc[(*loc, "2020-01-01")] = 0.0
+    params.loc[(*loc, "2021-01-01")] = 0.0
+    params.loc[(*loc, "2021-03-22")] = 0.3
+    params.loc[(*loc, "2021-04-07")] = 0.75
+    params.loc[(*loc, "2021-04-19")] = 0.95
+    params.loc[(*loc, "2021-06-01")] = 1.0
+
+    return params
 
 
 def _convert_index_to_int_where_possible(params):

--- a/src/testing/task_plot_share_of_educ_participants_with_rapid_test.py
+++ b/src/testing/task_plot_share_of_educ_participants_with_rapid_test.py
@@ -1,0 +1,50 @@
+import warnings
+
+import matplotlib.pyplot as plt
+import pandas as pd
+import pytask
+import seaborn as sns
+
+from src.config import BLD
+from src.simulation.plotting import style_plot
+from src.testing.shared import get_piecewise_linear_interpolation
+
+
+@pytask.mark.depends_on(BLD / "params.pkl")
+@pytask.mark.produces(
+    BLD / "data" / "testing" / "share_of_educ_participants_with_rapid_test.png"
+)
+def task_plot_share_of_educ_participants_with_rapid_test(depends_on, produces):
+    params = pd.read_pickle(depends_on)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message="indexing past lexsort depth may impact performance."
+        )
+        educ_workers_params = params.loc[("rapid_test_demand", "educ_worker_shares")]
+        students_params = params.loc[("rapid_test_demand", "student_shares")]
+
+    share_educ_workers = get_piecewise_linear_interpolation(educ_workers_params)
+    share_educ_workers = share_educ_workers.loc["2021-01-01":]
+
+    share_students = get_piecewise_linear_interpolation(students_params)
+    share_students = share_students.loc["2021-01-01":]
+
+    fig, ax = plt.subplots(figsize=(8, 3))
+    sns.lineplot(
+        x=share_educ_workers.index,
+        y=share_educ_workers,
+        ax=ax,
+        label="Teachers (School, Preschool, Nursery)",
+    )
+    sns.lineplot(
+        x=share_students.index,
+        y=share_students,
+        ax=ax,
+        label="School Students",
+    )
+    ax.set_title("Share Educ Participants Getting Rapid Test")
+    fig, ax = style_plot(fig, ax)
+    fig.tight_layout()
+
+    fig.savefig(produces)
+    plt.close()


### PR DESCRIPTION
- [x] Add parameters 
- [x] Plot piecewise linear functions

![share_of_educ_participants_with_rapid_test](https://user-images.githubusercontent.com/9567321/116665344-f62a7480-a999-11eb-8926-3c52cd7a9183.png)


- [x] Use compliance and parameters to fade in rapid tests
- [x] Adjust tests
- [ ] Add additional tests for `_get_eligible_educ_participants`, `_get_educ_worker_demand` and `_get_student_demand`
- [ ] Run simulations and compare