### PR TITLE
Rewrite pcr testing.

### DIFF
--- a/src/create_initial_states/task_build_full_params.py
+++ b/src/create_initial_states/task_build_full_params.py
@@ -78,9 +78,6 @@ def task_create_full_params(depends_on, produces):
     params.loc[("testing", "allocation", "rel_available_tests")] = 100_000
     params.loc[("testing", "processing", "rel_available_capacity")] = 100_000
 
-    # Testing parameters governing test demand
-    params.loc[("test_demand", "symptoms", "share_symptomatic_requesting_test")] = 0.5
-
     # Testing parameters governing rapid test demand
     # -----------------------------------------------
 

--- a/src/simulation/main_fall_scenarios/task_simulate_main_fall_scenarios.py
+++ b/src/simulation/main_fall_scenarios/task_simulate_main_fall_scenarios.py
@@ -48,18 +48,10 @@ def task_simulate_main_fall_scenario(
     init_start = start_date - pd.Timedelta(31, unit="D")
     init_end = start_date - pd.Timedelta(1, unit="D")
 
-    scenario_name = produces.parent.name
-    test_demand_log_path = (
-        produces.parent.parent / "test_demand_logging" / scenario_name
-    )
-    test_demand_log_path.mkdir(parents=True, exist_ok=True)
-
     virus_shares, simulation_inputs = load_simulation_inputs(
         depends_on,
         init_start,
         end_date,
-        test_demand_log_path=test_demand_log_path,
-        extend_ars_dfs=False,
     )
 
     initial_conditions = create_initial_conditions(

--- a/src/simulation/main_predictions/task_simulate_main_predictions.py
+++ b/src/simulation/main_predictions/task_simulate_main_predictions.py
@@ -56,18 +56,10 @@ def task_simulate_main_prediction(
     init_start = start_date - pd.Timedelta(31, unit="D")
     init_end = start_date - pd.Timedelta(1, unit="D")
 
-    scenario_name = produces.parent.name
-    test_demand_log_path = (
-        produces.parent.parent / "test_demand_logging" / scenario_name
-    )
-    test_demand_log_path.mkdir(parents=True, exist_ok=True)
-
     virus_shares, simulation_inputs = load_simulation_inputs(
         depends_on,
         init_start,
         end_date,
-        test_demand_log_path=test_demand_log_path,
-        extend_ars_dfs=True,
     )
 
     initial_conditions = create_initial_conditions(

--- a/src/simulation/main_specification.py
+++ b/src/simulation/main_specification.py
@@ -38,15 +38,7 @@ SIMULATION_DEPENDENCIES = {
     "params": BLD / "params.pkl",
     "rki_data": BLD / "data" / "processed_time_series" / "rki.pkl",
     "synthetic_data_path": BLD / "data" / "initial_states.parquet",
-    "test_shares_by_age_group": BLD
-    / "data"
-    / "testing"
-    / "test_shares_by_age_group.pkl",
-    "positivity_rate_by_age_group": BLD
-    / "data"
-    / "testing"
-    / "positivity_rate_by_age_group.pkl",
-    "positivity_rate_overall": BLD / "data" / "testing" / "positivity_rate_overall.pkl",
+    "characteristics_of_the_tested": BLD / "data" / "testing" / "characteristics_of_the_tested.csv",
     "virus_shares": BLD / "data" / "virus_strains" / "final_strain_shares.pkl",
     # py files
     "contacts_py": SRC / "contact_models" / "get_contact_models.py",
@@ -172,30 +164,19 @@ def build_main_scenarios(base_path):
     return nested_parametrization
 
 
-def load_simulation_inputs(
-    depends_on, init_start, end_date, test_demand_log_path, extend_ars_dfs=False
-):
-    test_inputs = {
-        "test_shares_by_age_group": pd.read_pickle(
-            depends_on["test_shares_by_age_group"]
-        ),
-        "positivity_rate_by_age_group": pd.read_pickle(
-            depends_on["positivity_rate_by_age_group"]
-        ),
-        "positivity_rate_overall": pd.read_pickle(
-            depends_on["positivity_rate_overall"]
-        ),
-    }
+def load_simulation_inputs(depends_on, init_start, end_date):
+    characteristics_of_the_tested = pd.read_csv(
+        depends_on["characteristics_of_the_tested"],
+        index_col="date",
+        parse_dates=["date"],
+    )
 
-    if extend_ars_dfs:
-        for name, df in test_inputs.items():
-            test_inputs[name] = _extend_df_into_future(df, end_date=end_date)
+    share_of_tests_for_symptomatics_series = characteristics_of_the_tested["share_symptomatic_lower_bound_extrapolated"]
 
     simulation_inputs = _get_testing_models(
         init_start=init_start,
         end_date=end_date,
-        test_demand_log_path=test_demand_log_path,
-        **test_inputs,
+        share_of_tests_for_symptomatics_series=share_of_tests_for_symptomatics_series,
     )
     simulation_inputs["initial_states"] = pd.read_parquet(depends_on["initial_states"])
     simulation_inputs["contact_models"] = get_all_contact_models()
@@ -272,17 +253,11 @@ def _extend_df_into_future(df, end_date):
 def _get_testing_models(
     init_start,
     end_date,
-    positivity_rate_overall,
-    test_shares_by_age_group,
-    positivity_rate_by_age_group,
-    test_demand_log_path,
+    share_of_tests_for_symptomatics_series,
 ):
     demand_test_func = partial(
         demand_test,
-        positivity_rate_overall=positivity_rate_overall,
-        test_shares_by_age_group=test_shares_by_age_group,
-        positivity_rate_by_age_group=positivity_rate_by_age_group,
-        log_path=test_demand_log_path,
+        share_of_tests_for_symptomatics_series=share_of_tests_for_symptomatics_series,
     )
     one_day = pd.Timedelta(1, unit="D")
     testing_models = {

--- a/src/simulation/main_specification.py
+++ b/src/simulation/main_specification.py
@@ -38,7 +38,10 @@ SIMULATION_DEPENDENCIES = {
     "params": BLD / "params.pkl",
     "rki_data": BLD / "data" / "processed_time_series" / "rki.pkl",
     "synthetic_data_path": BLD / "data" / "initial_states.parquet",
-    "characteristics_of_the_tested": BLD / "data" / "testing" / "characteristics_of_the_tested.csv",
+    "characteristics_of_the_tested": BLD
+    / "data"
+    / "testing"
+    / "characteristics_of_the_tested.csv",
     "virus_shares": BLD / "data" / "virus_strains" / "final_strain_shares.pkl",
     # py files
     "contacts_py": SRC / "contact_models" / "get_contact_models.py",
@@ -171,7 +174,9 @@ def load_simulation_inputs(depends_on, init_start, end_date):
         parse_dates=["date"],
     )
 
-    share_of_tests_for_symptomatics_series = characteristics_of_the_tested["share_symptomatic_lower_bound_extrapolated"]
+    share_of_tests_for_symptomatics_series = characteristics_of_the_tested[
+        "share_symptomatic_lower_bound_extrapolated"
+    ]
 
     simulation_inputs = _get_testing_models(
         init_start=init_start,

--- a/src/testing/task_get_and_plot_share_of_tests_for_symptomatics.py
+++ b/src/testing/task_get_and_plot_share_of_tests_for_symptomatics.py
@@ -51,14 +51,12 @@ def task_prepare_characteristics_of_the_tested(depends_on, produces):
         "share_symptomatic_upper_bound",
     ]
 
-
     df = df.set_index("date")
     to_concat = [df]
     for share in symptom_shares:
         extrapolated = _extrapolate_series_after_february(df[share])
         to_concat.append(extrapolated)
     df = pd.concat(to_concat, axis=1)
-
 
     colors = get_colors("categorical", len(symptom_shares))
     fig, ax = plt.subplots()
@@ -114,8 +112,12 @@ def _extrapolate_series_after_february(sr, end_date="2021-08-30"):
     end_date = pd.Timestamp(end_date)
     last_empirical_date = min(pd.Timestamp("2021-02-28"), sr.index.max())
     empirical_part = sr[:last_empirical_date]
-    extension_index = pd.date_range(last_empirical_date + pd.Timedelta(days=1), end_date)
-    extension_value = sr[last_empirical_date - pd.Timedelta(days=30): last_empirical_date].mean()
+    extension_index = pd.date_range(
+        last_empirical_date + pd.Timedelta(days=1), end_date
+    )
+    extension_value = sr[
+        last_empirical_date - pd.Timedelta(days=30) : last_empirical_date
+    ].mean()
     extension = pd.Series(extension_value, index=extension_index)
     out = pd.concat([empirical_part, extension])
     out.name = f"{sr.name}_extrapolated"

--- a/src/testing/task_get_and_plot_share_of_tests_for_symptomatics.py
+++ b/src/testing/task_get_and_plot_share_of_tests_for_symptomatics.py
@@ -2,6 +2,7 @@ import matplotlib.pyplot as plt
 import pandas as pd
 import pytask
 import seaborn as sns
+from estimagic.visualization.colors import get_colors
 
 from src.config import BLD
 from src.simulation.plotting import style_plot
@@ -37,7 +38,6 @@ def task_prepare_characteristics_of_the_tested(depends_on, produces):
 
     df = _clean_data(df)
     df = convert_weekly_to_daily(df.reset_index(), divide_by_7_cols=[])
-    df.to_csv(produces["data"])
 
     fig, ax = _plot_df_column(df, "mean_age")
     fig.tight_layout()
@@ -50,9 +50,27 @@ def task_prepare_characteristics_of_the_tested(depends_on, produces):
         "share_symptomatic_among_known",
         "share_symptomatic_upper_bound",
     ]
-    fig, ax = _plot_df_column(df, symptom_shares, "Symptomatic Shares")
+
+
+    df = df.set_index("date")
+    to_concat = [df]
+    for share in symptom_shares:
+        extrapolated = _extrapolate_series_after_february(df[share])
+        to_concat.append(extrapolated)
+    df = pd.concat(to_concat, axis=1)
+
+
+    colors = get_colors("categorical", len(symptom_shares))
+    fig, ax = plt.subplots()
+
+    for share, color in zip(symptom_shares, colors):
+        extrapolated = f"{share}_extrapolated"
+        sns.lineplot(x=df.index, y=df[share], ax=ax, color=color, label=share)
+        sns.lineplot(x=df.index, y=df[extrapolated], ax=ax, color=color)
     fig.tight_layout()
     fig.savefig(produces["symptom_shares"])
+    df = df.reset_index().rename(columns={"index": "date"})
+    df.to_csv(produces["data"])
 
 
 def _clean_data(df):
@@ -90,6 +108,18 @@ def _clean_data(df):
         df["share_symptomatic_lower_bound"] + df["share_without_symptom_status"]
     )
     return df
+
+
+def _extrapolate_series_after_february(sr, end_date="2021-08-30"):
+    end_date = pd.Timestamp(end_date)
+    last_empirical_date = min(pd.Timestamp("2021-02-28"), sr.index.max())
+    empirical_part = sr[:last_empirical_date]
+    extension_index = pd.date_range(last_empirical_date + pd.Timedelta(days=1), end_date)
+    extension_value = sr[last_empirical_date - pd.Timedelta(days=30): last_empirical_date].mean()
+    extension = pd.Series(extension_value, index=extension_index)
+    out = pd.concat([empirical_part, extension])
+    out.name = f"{sr.name}_extrapolated"
+    return out
 
 
 def _plot_df_column(df, cols, title=None):

--- a/src/testing/testing_models.py
+++ b/src/testing/testing_models.py
@@ -1,27 +1,4 @@
-"""Testing models, adjusted from Tobi's sid tutorial.
-
-We only model positive tests and assume there are no false positives or false negatives.
-Note this assumes that individuals' behavior is unaffected by a negative test result.
-
-This is very advantageous because only PCR tests are reported and antigen tests are not.
-Thus, since positive antigen tests are followed up with a PCR test, positive antigen
-tests show up in the test statistics and negative tests don't. So the positive tests
-reflect the true positive tests but the negative tests don't.
-
-Who gets a test as follows is completely determined in the demand_test function:
-
-Firstly, we calculate from the number of infected people in the simulation and the
-share_known_cases how many positive tests are to be distributed in the whole population.
-From this, using the overall positivity rate of tests we get to the full budget of tests
-to be distributed across the population.
-
-Using the ARS data, we get the share of tests (positive and negative) going to each
-age group. Using the age specific positivity rate - also reported in the ARS data -
-then gets us the number of positive tests to distribute in each age group.
-Using the RKI and ARS data therefore allows us to reflect the German testing strategy
-over age groups, e.g .preferential testing of older individuals.
-
-"""
+"""PCR testing model for sid."""
 import warnings
 
 import numpy as np
@@ -35,49 +12,20 @@ def demand_test(
     states,
     params,
     seed,
-    positivity_rate_overall,
-    test_shares_by_age_group,
-    positivity_rate_by_age_group,
-    log_path,
+    share_of_tests_for_symptomatics_series,
 ):
     """Test demand function.
 
-    Test demand is calculated in such a way that the demand fits to the empirical
-    distribution of positive tests in the empirical data.
-
-    We calculate the tests designated in each age group as follows:
-    Firstly, we calculate from the number of infected people in the simulation and the
-    share_known_cases how many positive tests are to
-    be distributed in the whole population. From this, using the overall positivity rate
-    of tests we get to the full budget of tests to be distributed across the population.
-    Using the ARS data, we get the share of tests (positive and negative) going to each
-    age group. Using the age specific positivity rate - also reported in the ARS data -
-    then gets us the number of positive tests to distribute in each age group.
-    Using the RKI and ARS data therefore allows us to reflect the German testing
-    strategy over age groups, e.g .preferential testing of older individuals.
-
-    In each age group we first distribute tests among those that received a positive
-    rapid test in the previous period. In addition, symptomatic people request a test
-    with the `share_symptomatic_requesting_test` probability.
-    We then distribute the remaining tests randomly among the remaining currently
-    infectious such that we use up the full test budget in each age group.
+    Contrary to the name this function combines test demand and test allocation.
 
     Args:
         states (pandas.DataFrame): The states of the individuals.
         params (pandas.DataFrame): A DataFrame with parameters. It needs to contain
             the entry ("test_demand", "symptoms", "share_symptomatic_requesting_test").
         seed (int): Seed for reproducibility.
-        share_known_cases (pandas.Series): share of infections that is detected.
-        positivity_rate_overall (pandas.Series): share of total tests that was positive.
-        test_shares_by_age_group (pandas.Series or pandas.DataFrame):
-            share of tests that was administered to each age group. If a Series the
-            index are the age groups. If a DataFrame, the index are the dates and
-            the columns are the age groups.
-        positivity_rate_by_age_group (pandas.Series or pandas.DataFrame):
-            share of tests that was positive in each age group. If a Series the
-            index are the age groups. If a DataFrame, the index are the dates and
-            the columns are the age groups.
-        log_path (pathlib.Path): Path to which the intermediate results will be saved.
+        share_of_tests_for_symptomatics_series (pandas.Series): Series with date index
+            that indicates the share of positive tests that were allocated to
+            symptomatic people.
 
     Returns:
         demand_probability (numpy.ndarray, pandas.Series): An array or a series
@@ -85,138 +33,69 @@ def demand_test(
 
     """
     np.random.seed(seed)
-    n_newly_infected = states["newly_infected"].sum()
-
     date = get_date(states)
-    if isinstance(test_shares_by_age_group, pd.DataFrame):
-        test_shares_by_age_group = test_shares_by_age_group.loc[date]
-    if isinstance(positivity_rate_by_age_group, pd.DataFrame):
-        positivity_rate_by_age_group = positivity_rate_by_age_group.loc[date]
-    if isinstance(positivity_rate_overall, pd.Series):
-        positivity_rate_overall = positivity_rate_overall.loc[date]
-    symptom_loc = ("test_demand", "symptoms", "share_symptomatic_requesting_test")
-    share_symptomatic = params.loc[symptom_loc, "value"]
-    if share_symptomatic > 1.0 or share_symptomatic < 0:
-        raise ValueError(
-            "The share of symptomatic individuals requesting a test must lie in the "
-            f"[0, 1] interval, you specified {share_symptomatic}"
-        )
 
-    rapid_tests_loc = (
-        "test_demand",
-        "shares",
-        "share_w_positive_rapid_test_requesting_test",
-    )
+    # extract parameters
     with warnings.catch_warnings():
         warnings.filterwarnings(
             "ignore", message="indexing past lexsort depth may impact performance."
         )
+
+        loc = ("test_demand", "shares", "share_w_positive_rapid_test_requesting_test")
+        share_requesting_confirmation = params.loc[loc, "value"]
+
         params_slice = params.loc[("share_known_cases", "share_known_cases")]
-        share_requesting_confirmation = params.loc[rapid_tests_loc, "value"]
 
     share_known_cases = get_piecewise_linear_interpolation_for_one_day(
         date, params_slice
     )
 
-    # get budget of positive tests to distribute
-    n_pos_tests_for_each_group = _calculate_positive_tests_to_distribute_per_age_group(
-        n_newly_infected=n_newly_infected,
+    share_of_tests_for_symptomatics = share_of_tests_for_symptomatics_series[date]
+
+    test_demand_from_share_known_cases = _calculate_test_demand_from_share_known_cases(
+        states=states,
         share_known_cases=share_known_cases,
-        positivity_rate_overall=positivity_rate_overall,
-        test_shares_by_age_group=test_shares_by_age_group,
-        positivity_rate_by_age_group=positivity_rate_by_age_group,
+        share_of_tests_for_symptomatics=share_of_tests_for_symptomatics,
     )
-    n_newly_infected_by_group = states.groupby("age_group_rki")["newly_infected"].sum()
-    implied_share_known_cases = n_pos_tests_for_each_group / n_newly_infected_by_group
 
-    unconstrained_demanded = pd.Series(False, index=states.index)
-
-    receiving_confirmation = _request_pcr_confirmation_of_rapid_test(
+    test_demand_from_rapid_tests = _calculate_test_demand_from_rapid_tests(
         states, share_requesting_confirmation
     )
-    symptomatic_requests = _request_pcr_test_bc_of_symptoms(states, share_symptomatic)
 
-    unconstrained_demanded = receiving_confirmation | symptomatic_requests
-
-    # scale demand
-    demands_by_age_group = unconstrained_demanded.groupby(states["age_group_rki"]).sum()
-    remaining = n_pos_tests_for_each_group - demands_by_age_group
-    demanded = _scale_demand_up_or_down(unconstrained_demanded, states, remaining)
-
-    if (remaining < 0).any():
-        save_path = log_path / f"{date.date()}.pkl"
-        to_save = {
-            "n_pos_tests_for_each_group": n_pos_tests_for_each_group,
-            "demands_by_age_group": demands_by_age_group,
-            "symptomatic_requests": symptomatic_requests.groupby(
-                states["age_group_rki"]
-            ).sum(),
-            "receiving_confirmation": receiving_confirmation.groupby(
-                states["age_group_rki"]
-            ).sum(),
-            "scaled": demanded.groupby(states["age_group_rki"]).sum(),
-            "implied_share_known_cases": implied_share_known_cases,
-            "supply_inputs": {
-                "n_newly_infected": n_newly_infected,
-                "share_known_cases": share_known_cases,
-                "positivity_rate_overall": positivity_rate_overall,
-                "test_shares_by_age_group": test_shares_by_age_group,
-                "positivity_rate_by_age_group": positivity_rate_by_age_group,
-            },
-        }
-        pd.to_pickle(to_save, save_path)
+    demanded = test_demand_from_share_known_cases | test_demand_from_rapid_tests
 
     return demanded
 
 
-def _calculate_positive_tests_to_distribute_per_age_group(
-    n_newly_infected,
-    share_known_cases,
-    positivity_rate_overall,
-    test_shares_by_age_group,
-    positivity_rate_by_age_group,
-):
-    """Calculate how many positive test results each age group gets.
+def _calculate_test_demand_from_share_known_cases(states, share_known_cases, share_of_tests_for_symptomatics):
+    n_newly_infected = states["newly_infected"].sum()
+    n_pos_tests = n_newly_infected * share_known_cases
+    untested = ~states["knows_immune"] & ~states["pending_test"]
 
-    Using the RKI and ARS data allows us to reflect the German testing
-    strategy over age groups, e.g .preferential testing of older individuals.
+    symptomatic_untested = states["symptomatic"] & untested
+    n_symptomatic_untested = symptomatic_untested.sum()
 
-    Note this ignores inaccuracy of tests (false positives and negatives).
+    desired_n_tests_symptomatic = n_pos_tests * share_of_tests_for_symptomatics
+    n_tests_symptomatic = int(min(desired_n_tests_symptomatic, n_symptomatic_untested))
 
-    We calculate the number of positive tests designated in each age group as follows:
+    n_tests_remaining = int(n_pos_tests - n_tests_symptomatic)
 
-    Firstly, we calculate from the number of infected people in the simulation and the
-    share_known_cases how many tests are to be distributed in the whole population.
-    From this, using the overall positivity rate of tests we get to the full budget
-    of tests to be distributed across the population.
-    Using the ARS data on the share of all tests that go to each age group, we get
-    the number of (positive and negative) tests going to each age group.
-    Using the age specific positivity rate - also reported in the ARS data -
-    then gets us the number of positive tests to distribute in each age group.
+    symptomatic_pool = states.index[symptomatic_untested]
+    symptomatic_sampled = np.random.choice(symptomatic_pool, size=n_tests_symptomatic, replace=False)
 
-    Args:
-        n_newly_infected (int): number of newly infected individuals.
-        share_known_cases (float): share of infections that is detected.
-        positivity_rate_overall (float): share of total tests that was positive.
-        test_shares_by_age_group (pandas.Series): share of tests that was administered
-            to each age group.
-        positivity_rate_by_age_group (pandas.Series): share of tests that was positive
-            in each age group.
+    is_remaining_candidate = states["currently_infected"] & ~states["symptomatic"] & untested
+    remaining_pool = states.index[is_remaining_candidate]
+    remaining_sampled = np.random.choice(remaining_pool, size=n_tests_remaining, replace=False)
 
-    Returns:
-        n_pos_tests_for_age_group (pandas.Series): number of positive tests
-            to distribute in each age group.
+    demand = pd.Series(False, index=states.index)
 
-    """
-    n_pos_tests_overall = n_newly_infected * share_known_cases
-    n_tests_overall = n_pos_tests_overall / positivity_rate_overall
-    n_tests_for_each_group = n_tests_overall * test_shares_by_age_group
-    n_pos_tests_for_each_group = n_tests_for_each_group * positivity_rate_by_age_group
-    n_pos_tests_for_each_group_int = n_pos_tests_for_each_group.astype(int)
-    return n_pos_tests_for_each_group_int
+    for loc in [symptomatic_sampled, remaining_sampled]:
+        demand[loc] = True
+
+    return demand
 
 
-def _request_pcr_confirmation_of_rapid_test(states, share_requesting_confirmation):
+def _calculate_test_demand_from_rapid_tests(states, share_requesting_confirmation):
     received_rapid_test = states["cd_received_rapid_test"] == 0
     pos_rapid_test = states["is_tested_positive_by_rapid_test"]
     pool = states[received_rapid_test & pos_rapid_test].index
@@ -229,125 +108,6 @@ def _request_pcr_confirmation_of_rapid_test(states, share_requesting_confirmatio
     demanding_verification = states.index.isin(demands_verification_locs)
     getting_confirmation = states["currently_infected"] & demanding_verification
     return getting_confirmation
-
-
-def _request_pcr_test_bc_of_symptoms(states, share_symptomatic_requesting_test):
-    """Return who requests a rapid test because of symptoms.
-
-    Args:
-        states (pandas.DataFrame)
-        share_symptomatic_requesting_test (float): Share of individuals that
-            developed symptoms the day before requesting a test.
-
-    Returns:
-        requests_rapid_test (pandas.Series): boolean Series. Index is the same as
-            states. True for individuals requesting a PCR test because of having
-            developed symptoms the day before.
-
-    """
-    developed_symptoms_yesterday = states["cd_symptoms_true"] == -1
-    untested = ~states["pending_test"] & ~states["knows_immune"]
-    symptomatic_without_test = developed_symptoms_yesterday & untested
-    if share_symptomatic_requesting_test == 1.0:
-        requests_rapid_test_locs = states[symptomatic_without_test].index
-    else:
-        # this ignores the designated number of tests per age group.
-        # Adjusting the number of tests to the designated number is done in
-        # `_scale_demand_up_or_down` below.
-        n_to_demand = int(
-            share_symptomatic_requesting_test * symptomatic_without_test.sum()
-        )
-        pool = states[symptomatic_without_test].index
-        requests_rapid_test_locs = np.random.choice(
-            size=n_to_demand, a=pool, replace=False
-        )
-
-    requests_rapid_test = pd.Series(
-        states.index.isin(requests_rapid_test_locs), index=states.index
-    )
-    return requests_rapid_test
-
-
-def _scale_demand_up_or_down(demanded, states, remaining):
-    """Adjust the demand for tests to match the designated tests in each age group.
-
-    After symptomatic individuals have preferentially received tests the budget for
-    tests in each age group may not be used up yet or exceeded. Here we remove the
-    excess tests in the age groups where they exceed the budget. In groups were not
-    all tests are used for symptomatic individuals we distribute the tests among the
-    remaining infectious individuals that have no pending test and do not know their
-    infection state yet.
-
-    Args:
-        demanded (pandas.Series): Boolean Series with same index as states. It is
-            True for people who demanded a test.
-        states (pandas.DataFrame): sid states DataFrame
-        remaining (pandas.Series): index are the RKI age groups, values are the
-            number of remaining tests (can be negative) in each age group.
-
-    Returns:
-        demanded (pandas.Series): Boolean Series with same index as states. It is
-            True for people who demanded a test. The number of tests in each age
-            group have been adjusted to match the number of designated tests in
-            that age group.
-
-    """
-    demanded = demanded.copy(deep=True)
-    for group, remainder in remaining.items():
-        if remainder == 0:
-            continue
-        elif remainder > 0:
-            n_undemanded_tests = int(abs(remainder))
-            demanded = _increase_test_demand(
-                demanded, states, n_undemanded_tests, group
-            )
-        else:  # remainder < 0
-            n_to_remove = int(abs(remainder))
-            demanded = _decrease_test_demand(demanded, states, n_to_remove, group)
-    return demanded
-
-
-def _decrease_test_demand(demanded, states, n_to_remove, group):
-    """Decrease the number of tests demanded in an age group by a certain number.
-
-    This is called when the endogenously demanded tests (symptomatics + educ workers)
-    already exceed the designated number of positive tests in an age group.
-
-    """
-    demanded = demanded.copy(deep=True)
-
-    is_candidate = demanded.to_numpy() & (states["age_group_rki"] == group).to_numpy()
-    demanding_test_in_age_group = demanded.index.to_numpy()[is_candidate]
-    drawn = np.random.choice(
-        a=demanding_test_in_age_group, size=n_to_remove, replace=False
-    )
-    demanded.loc[drawn] = False
-    return demanded
-
-
-def _increase_test_demand(demanded, states, n_undemanded_tests, group):
-    """Randomly increase the number of tests demanded in an age group.
-    This is the case where we have additional positive tests to distribute.
-
-    """
-    demanded = demanded.copy(deep=True)
-
-    right_age_group = states["age_group_rki"] == group
-    untested = ~states["pending_test"] & ~states["knows_immune"]
-    condition = right_age_group & untested & states["currently_infected"]
-    infected_untested = states.index[condition & ~demanded]
-
-    if len(infected_untested) >= n_undemanded_tests:
-        drawn = np.random.choice(infected_untested, n_undemanded_tests, replace=False)
-    else:
-        date = get_date(states)
-        warnings.warn(
-            f"\n\nThe implied share_known_cases for age group {group} is >1 "
-            f"on date {date.date()} ({date.day_name()}).\n\n"
-        )
-        drawn = infected_untested
-    demanded.loc[drawn] = True
-    return demanded
 
 
 def allocate_tests(n_allocated_tests, demands_test, states, params, seed):  # noqa: U100

--- a/src/testing/testing_models.py
+++ b/src/testing/testing_models.py
@@ -67,7 +67,9 @@ def demand_test(
     return demanded
 
 
-def _calculate_test_demand_from_share_known_cases(states, share_known_cases, share_of_tests_for_symptomatics):
+def _calculate_test_demand_from_share_known_cases(
+    states, share_known_cases, share_of_tests_for_symptomatics
+):
     n_newly_infected = states["newly_infected"].sum()
     n_pos_tests = n_newly_infected * share_known_cases
     untested = ~states["knows_immune"] & ~states["pending_test"]
@@ -81,11 +83,17 @@ def _calculate_test_demand_from_share_known_cases(states, share_known_cases, sha
     n_tests_remaining = int(n_pos_tests - n_tests_symptomatic)
 
     symptomatic_pool = states.index[symptomatic_untested]
-    symptomatic_sampled = np.random.choice(symptomatic_pool, size=n_tests_symptomatic, replace=False)
+    symptomatic_sampled = np.random.choice(
+        symptomatic_pool, size=n_tests_symptomatic, replace=False
+    )
 
-    is_remaining_candidate = states["currently_infected"] & ~states["symptomatic"] & untested
+    is_remaining_candidate = (
+        states["currently_infected"] & ~states["symptomatic"] & untested
+    )
     remaining_pool = states.index[is_remaining_candidate]
-    remaining_sampled = np.random.choice(remaining_pool, size=n_tests_remaining, replace=False)
+    remaining_sampled = np.random.choice(
+        remaining_pool, size=n_tests_remaining, replace=False
+    )
 
     demand = pd.Series(False, index=states.index)
 

--- a/tests/test_testing_models.py
+++ b/tests/test_testing_models.py
@@ -1,12 +1,7 @@
 import pandas as pd
 import pytest
 
-from src.testing.testing_models import (
-    _calculate_positive_tests_to_distribute_per_age_group,
-)
-from src.testing.testing_models import _request_pcr_confirmation_of_rapid_test
-from src.testing.testing_models import _request_pcr_test_bc_of_symptoms
-from src.testing.testing_models import _scale_demand_up_or_down
+from src.testing.testing_models import _calculate_test_demand_from_rapid_tests
 from src.testing.testing_models import allocate_tests
 from src.testing.testing_models import process_tests
 
@@ -65,42 +60,6 @@ def params():
 # -----------------------------------------------------------------------------
 
 
-def test_scale_demand_up_or_down(states):
-    demanded = pd.Series([True, True] + [False, True] * 4, index=states.index)
-    states["infectious"] = True
-    states["currently_infected"] = states.eval(
-        "(infectious | symptomatic | (cd_infectious_true >= 0))"
-    )
-    remaining = pd.Series([-2, 0, 2], index=["0-4", "5-14", "15-34"])
-    expected_vals = [False, False] + [False, True] * 2 + [True] * 4
-    expected = pd.Series(data=expected_vals, index=states.index)
-    res = _scale_demand_up_or_down(
-        demanded=demanded, states=states, remaining=remaining
-    )
-    pd.testing.assert_series_equal(res, expected, check_names=False)
-
-
-def test_calculate_positive_tests_to_distribute_per_age_group():
-    n_newly_infected = 20
-    share_known_cases = 0.5
-    positivity_rate_overall = 0.2
-    test_shares_by_age_group = pd.Series(
-        [0.4, 0.4, 0.2], index=["0-4", "5-14", "15-34"]
-    )
-    positivity_rate_by_age_group = pd.Series(
-        [0.05, 0.2, 0.5], index=["0-4", "5-14", "15-34"]
-    )
-    res = _calculate_positive_tests_to_distribute_per_age_group(
-        n_newly_infected,
-        share_known_cases,
-        positivity_rate_overall,
-        test_shares_by_age_group,
-        positivity_rate_by_age_group,
-    )
-    expected = pd.Series([1, 4, 5], index=["0-4", "5-14", "15-34"])
-    pd.testing.assert_series_equal(res, expected, check_names=False, check_dtype=False)
-
-
 def test_allocate_tests(states):
     demands_test = pd.Series(True, index=states.index)
     res = allocate_tests(
@@ -136,19 +95,7 @@ def symptom_states():
     return states
 
 
-def test_request_pcr_test_bc_of_symptoms_no_one(symptom_states):
-    res = _request_pcr_test_bc_of_symptoms(symptom_states, 0.0)
-    expected = pd.Series(False, index=symptom_states.index)
-    pd.testing.assert_series_equal(res, expected)
-
-
-def test_request_pcr_test_bc_of_symptoms_everyone(symptom_states):
-    res = _request_pcr_test_bc_of_symptoms(symptom_states, 1.0)
-    expected = pd.Series([False, False, False, False, True], index=symptom_states.index)
-    pd.testing.assert_series_equal(res, expected)
-
-
-def test__request_pcr_confirmation_of_rapid_test():
+def test_calculate_test_demand_from_rapid_tests():
     states = pd.DataFrame()
     # cases:
     # 0: not tested today
@@ -160,6 +107,6 @@ def test__request_pcr_confirmation_of_rapid_test():
     states["is_tested_positive_by_rapid_test"] = [True, False, True, True, False]
     states["currently_infected"] = [False, True, False, True, False]
 
-    res = _request_pcr_confirmation_of_rapid_test(states, 1)
+    res = _calculate_test_demand_from_rapid_tests(states, 1)
     expected = pd.Series([False, False, False, True, False], index=states.index)
     pd.testing.assert_series_equal(res, expected, check_names=False)


### PR DESCRIPTION
### Current behavior

PRC testing demand uses ARS data to get heterogeneous shares of known cases across age groups. This data is unreliable. Without reweighting it does not reproduce the observed infection numbers by age group. With reweighting, it does not produce a realistic ordering of the share of known cases. 

### Desired behavior

Get rid of ARS data; Get heterogeneity in share of known cases through test demand by symptomatic individuals. 

