### PR TITLE
Test household members when other members get a positive test or become symptomatiac

### DIFF
--- a/src/create_initial_states/task_build_full_params.py
+++ b/src/create_initial_states/task_build_full_params.py
@@ -116,8 +116,7 @@ def task_create_full_params(depends_on, produces):
     params.loc[(*offer_loc, "2021-06-15"), "value"] = 0.7
 
     params = _add_educ_rapid_test_fade_in_params(params)
-
-    params.loc[("rapid_test_demand", "hh_member_demand", "share"), "value"] = 0.85
+    params = _add_hh_rapid_test_fade_in_params(params)
 
     # seasonality parameter
     params.loc[("seasonality_effect", "seasonality_effect", "seasonality_effect")] = 0.2
@@ -238,6 +237,35 @@ def _add_educ_rapid_test_fade_in_params(params):
     params.loc[(*loc, "2021-04-07")] = 0.75
     params.loc[(*loc, "2021-04-19")] = 0.95
     params.loc[(*loc, "2021-06-01")] = 1.0
+
+    return params
+
+
+def _add_hh_rapid_test_fade_in_params(params):
+    """Add the share of people demanding a rapid test after a Covid household event.
+
+    Bürgertests started in mid March but demand was very low initially
+    (https://bit.ly/3ehmGcj). Anecdotally, the demand continues to be limited.
+
+    First tests to self-administer became available starting March 6.
+    However, supply was very limited in the beginning (https://bit.ly/3xJCIn8).
+
+    All values are arbitrary.
+
+    We assume that for Easter visits many people demanded tests for the first
+    time and are more likely to test themselves after knowing where to get them.
+
+    """
+    params = params.copy(deep=True)
+    loc = ("rapid_test_demand", "hh_member_demand")
+    params.loc[(*loc, "2020-01-01"), "value"] = 0
+    params.loc[(*loc, "2021-03-10"), "value"] = 0
+    params.loc[(*loc, "2021-03-25"), "value"] = 0.1
+    params.loc[(*loc, "2021-04-05"), "value"] = 0.3
+    params.loc[(*loc, "2021-05-01"), "value"] = 0.4
+    params.loc[(*loc, "2021-05-15"), "value"] = 0.5
+    params.loc[(*loc, "2021-06-01"), "value"] = 0.75
+    params.loc[(*loc, "2021-10-01"), "value"] = 0.75
 
     return params
 

--- a/src/create_initial_states/task_build_full_params.py
+++ b/src/create_initial_states/task_build_full_params.py
@@ -117,6 +117,8 @@ def task_create_full_params(depends_on, produces):
 
     params = _add_educ_rapid_test_fade_in_params(params)
 
+    params.loc[("rapid_test_demand", "hh_member_demand", "share"), "value"] = 0.85
+
     # seasonality parameter
     params.loc[("seasonality_effect", "seasonality_effect", "seasonality_effect")] = 0.2
 

--- a/src/create_initial_states/task_build_full_params.py
+++ b/src/create_initial_states/task_build_full_params.py
@@ -84,7 +84,7 @@ def task_create_full_params(depends_on, produces):
     # source: https://bit.ly/3gHlcKd (section 3.5, 2021-03-09, accessed 2021-04-28)
     params.loc[
         ("test_demand", "shares", "share_w_positive_rapid_test_requesting_test"),
-    ] = 0.85
+    ] = 0.4
 
     # Only 60% of workers receiving a test offer accept it regularly
     # source: https://bit.ly/3t1z0lf (COSMO, 2021-04-21)

--- a/src/simulation/plotting.py
+++ b/src/simulation/plotting.py
@@ -1,4 +1,5 @@
 import matplotlib.pyplot as plt
+import numpy as np
 import pandas as pd
 import seaborn as sns
 from matplotlib.dates import AutoDateLocator
@@ -157,14 +158,18 @@ def plot_incidences(incidences, n_single_runs, title, name_to_label, rki=False):
     return fig, ax
 
 
-def style_plot(fig, ax):
-    ax.set_ylabel("")
-    ax.set_xlabel("Datum")
-    n_days = ax.get_xlim()[1] - ax.get_xlim()[0]
-    date_form = DateFormatter("%d.%m") if n_days < 100 else DateFormatter("%m/%Y")
-    ax.xaxis.set_major_formatter(date_form)
-    loc = AutoDateLocator(minticks=5, maxticks=12)
-    ax.xaxis.set_major_locator(loc)
-    ax.grid(axis="y")
+def style_plot(fig, axes):
+    if not isinstance(axes, np.ndarray):
+        axes = [axes]
+
+    for ax in axes:
+        ax.set_ylabel("")
+        ax.set_xlabel("Datum")
+        n_days = ax.get_xlim()[1] - ax.get_xlim()[0]
+        date_form = DateFormatter("%d.%m") if n_days < 100 else DateFormatter("%m/%Y")
+        ax.xaxis.set_major_formatter(date_form)
+        loc = AutoDateLocator(minticks=5, maxticks=12)
+        ax.xaxis.set_major_locator(loc)
+        ax.grid(axis="y")
     sns.despine()
     return fig, ax

--- a/src/testing/rapid_tests.py
+++ b/src/testing/rapid_tests.py
@@ -61,7 +61,7 @@ def rapid_test_demand(
 
     # get housheold member inputs
     hh_member_demand_share = get_piecewise_linear_interpolation_for_one_day(
-        hh_member_params
+        date, hh_member_params
     )
 
     work_demand = _calculate_work_rapid_test_demand(

--- a/src/testing/rapid_tests.py
+++ b/src/testing/rapid_tests.py
@@ -40,7 +40,7 @@ def rapid_test_demand(
         educ_workers_params = params.loc[("rapid_test_demand", "educ_worker_shares")]
         students_params = params.loc[("rapid_test_demand", "student_shares")]
         hh_member_demand_share = params.loc[
-            ("rapid_test_demand", "hh_member_demand", "share")
+            ("rapid_test_demand", "hh_member_demand", "share"), "value"
         ]
 
     # get work demand inputs

--- a/src/testing/rapid_tests.py
+++ b/src/testing/rapid_tests.py
@@ -188,7 +188,8 @@ def _calculate_hh_member_rapid_test_demand(states, hh_member_demand_share):
     """
     had_event_in_hh = _determine_if_hh_had_event(states)
     would_request_test = states["quarantine_compliance"] >= (1 - hh_member_demand_share)
-    hh_demand = had_event_in_hh & would_request_test
+    not_tested_within_3_days = states["cd_received_rapid_test"] < -3
+    hh_demand = had_event_in_hh & would_request_test & not_tested_within_3_days
     return hh_demand
 
 

--- a/src/testing/rapid_tests.py
+++ b/src/testing/rapid_tests.py
@@ -202,19 +202,14 @@ def _determine_if_hh_had_event(states):
             case in their household.
 
     """
-    new_symptomatic_in_hh = (
-        (states["cd_symptoms_true"] == -1).groupby(states["hh_id"]).transform(np.any)
+    rapid_test_event = (states["cd_received_rapid_test"] == -1) & (
+        states["is_tested_positive_by_rapid_test"]
     )
-    new_case_in_hh = states["new_known_case"].groupby(states["hh_id"]).transform(np.any)
+    is_event = (
+        rapid_test_event | states["new_known_case"] | (states["cd_symptoms_true"] == -1)
+    )
+    had_event_in_hh = is_event.groupby(states["hh_id"]).transform(np.any)
 
-    received_rapid_test = states["cd_received_rapid_test"] == -1
-    pos_rapid_test = states["is_tested_positive_by_rapid_test"]
-    received_pos_rapid_test = received_rapid_test & pos_rapid_test
-    new_pos_rapid_test_in_hh = received_pos_rapid_test.groupby(
-        states["hh_id"]
-    ).transform(np.any)
-
-    had_event_in_hh = new_symptomatic_in_hh | new_case_in_hh | new_pos_rapid_test_in_hh
     return had_event_in_hh
 
 

--- a/src/testing/rapid_tests.py
+++ b/src/testing/rapid_tests.py
@@ -39,9 +39,7 @@ def rapid_test_demand(
         ]
         educ_workers_params = params.loc[("rapid_test_demand", "educ_worker_shares")]
         students_params = params.loc[("rapid_test_demand", "student_shares")]
-        hh_member_demand_share = params.loc[
-            ("rapid_test_demand", "hh_member_demand", "share"), "value"
-        ]
+        hh_member_params = params.loc[("rapid_test_demand", "hh_member_demand")]
 
     # get work demand inputs
     share_of_workers_with_offer = get_piecewise_linear_interpolation_for_one_day(
@@ -59,6 +57,11 @@ def rapid_test_demand(
     )
     student_multiplier = get_piecewise_linear_interpolation_for_one_day(
         date, students_params
+    )
+
+    # get housheold member inputs
+    hh_member_demand_share = get_piecewise_linear_interpolation_for_one_day(
+        hh_member_params
     )
 
     work_demand = _calculate_work_rapid_test_demand(

--- a/src/testing/task_plot_share_of_hh_members_demanding_test.py
+++ b/src/testing/task_plot_share_of_hh_members_demanding_test.py
@@ -1,0 +1,60 @@
+import warnings
+
+import matplotlib.pyplot as plt
+import pandas as pd
+import pytask
+import seaborn as sns
+
+from src.config import BLD
+from src.config import POPULATION_GERMANY
+from src.simulation.plotting import style_plot
+from src.testing.shared import get_piecewise_linear_interpolation
+
+
+@pytask.mark.depends_on(
+    {
+        "params": BLD / "params.pkl",
+        "rki": BLD / "data" / "processed_time_series" / "rki.pkl",
+    }
+)
+@pytask.mark.produces(
+    BLD / "data" / "testing" / "share_of_hh_members_with_rapid_test_after_hh_event.png"
+)
+def task_plot_share_of_workers_receiving_test_offer(depends_on, produces):
+    rki = pd.read_pickle(BLD / "data" / "processed_time_series" / "rki.pkl")
+    rki = rki.groupby("date")["newly_infected"].sum()
+    rki = rki.rolling(7).sum().dropna()
+    rki = 100_000 * rki / POPULATION_GERMANY
+    rki = rki["2021-03-01":]
+
+    params = pd.read_pickle(depends_on["params"])
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message="indexing past lexsort depth may impact performance."
+        )
+        params_slice = params.loc[("rapid_test_demand", "hh_member_demand")]
+    share_hh_members_demanding_test = get_piecewise_linear_interpolation(params_slice)
+    share_hh_members_demanding_test = share_hh_members_demanding_test.loc[
+        "2021-03-01" : rki.index.max()
+    ]
+
+    fig, axes = plt.subplots(2, figsize=(10, 10), sharex=True)
+    sns.lineplot(x=rki.index, y=rki, ax=axes[0])
+    axes[0].grid()
+    axes[0].set_title("Incidence")
+
+    sns.lineplot(
+        x=share_hh_members_demanding_test.index,
+        y=share_hh_members_demanding_test,
+        ax=axes[1],
+    )
+    axes[1].grid()
+    axes[1].set_title(
+        "Share of Household Members Demanding Rapid Test\n"
+        "When Household Member Tests Positive Or Becomes Symptomatic"
+    )
+    fig, axes = style_plot(fig, axes)
+    fig.tight_layout()
+
+    fig.savefig(produces)
+    plt.close()


### PR DESCRIPTION
As expected household members demanding rapid tests when there are positive tests or symptomatic individuals in their households has a sizable effect on infection numbers:

![image](https://user-images.githubusercontent.com/9567321/117114037-9c57ef00-ad8b-11eb-944b-713d285422c3.png)
