### PR TITLE
Various improvements 2

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -1,3 +1,9 @@
+"""The global config file.
+
+BE CAREFUL WHEN CHANGING THINGS HERE BECAUSE THIS FILE IS NOT A DIRECT DEPENDENCY OF ANY
+TASK.
+
+"""
 import warnings
 from pathlib import Path
 

--- a/src/config.py
+++ b/src/config.py
@@ -1,7 +1,9 @@
 """The global config file.
 
-BE CAREFUL WHEN CHANGING THINGS HERE BECAUSE THIS FILE IS NOT A DIRECT DEPENDENCY OF ANY
-TASK.
+CAREFUL: THIS FILE IS NOT SPECIFIED AS THE DEPENDENCY OF ANY TASK BECAUSE OTHERWISE
+CHANGING THE FAST FLAG WOULD ALWAYS TRIGGER A RERUN OF EVERY TASK.
+IF YOU CHANGE ANYTHING ELSE HERE MAKE SURE TO DO A DISTCLEAN AFTERWARDS OR CAREFULLY
+REMOVE EVERYTHING THAT IMPORTS THE VARIABLE YOU CHANGED.
 
 """
 import warnings
@@ -9,11 +11,6 @@ from pathlib import Path
 
 import pandas as pd
 import sid
-
-SID_DEPENDENCIES = {}
-for path in Path(sid.__path__[0]).iterdir():
-    if path.suffix == ".py":
-        SID_DEPENDENCIES[f"sid_{path.name}"] = path.resolve()
 
 SUMMER_SCENARIO_START = "2021-05-17"
 
@@ -30,6 +27,12 @@ This means there 30 simulation runs overall.
 If 'full' 20 seeds are used for each scenario.
 
 """
+
+SID_DEPENDENCIES = {}
+for path in Path(sid.__path__[0]).iterdir():
+    if path.suffix == ".py":
+        SID_DEPENDENCIES[f"sid_{path.name}"] = path.resolve()
+
 
 try:
     import pyarrow  # noqa: F401

--- a/src/contact_models/task_create_contact_params.py
+++ b/src/contact_models/task_create_contact_params.py
@@ -8,7 +8,6 @@ import seaborn as sns
 from estimagic import minimize
 
 from src.config import BLD
-from src.config import SRC
 
 
 def _create_parametrization():
@@ -88,7 +87,6 @@ PARAMETRIZATION = _create_parametrization()
 @pytask.mark.depends_on(
     {
         "data": BLD / "data" / "mossong_2008" / "contact_data.pkl",
-        "config.py": SRC / "config.py",
     }
 )
 @pytask.mark.parametrize("specs, produces", PARAMETRIZATION)

--- a/src/create_initial_states/task_build_full_params.py
+++ b/src/create_initial_states/task_build_full_params.py
@@ -30,7 +30,6 @@ _DEPENDENCIES = {
     "vacations": BLD / "data" / "vacations.pkl",
     "infection_probs": SRC / "simulation" / "infection_probs.pkl",
     "susceptibility": SRC / "original_data" / "susceptibility.csv",
-    "config.py": SRC / "config.py",
     "contact_models.py": SRC / "contact_models" / "get_contact_models.py",
     "covid_epi_params": EPI_PARAMS_PATH,
 }

--- a/src/create_initial_states/task_check_initial_states.py
+++ b/src/create_initial_states/task_check_initial_states.py
@@ -6,7 +6,6 @@ import seaborn as sns
 
 from src.config import BLD
 from src.config import POPULATION_GERMANY
-from src.config import SRC
 
 
 @pytask.mark.depends_on(
@@ -34,7 +33,6 @@ from src.config import SRC
         / "age_groups.parquet",
         "vacations": BLD / "data" / "vacations.pkl",
         "work_multiplier": BLD / "policies" / "work_multiplier.csv",
-        "config.py": SRC / "config.py",
     }
 )
 @pytask.mark.produces(BLD / "data" / "comparison_of_age_group_distributions.png")

--- a/src/create_initial_states/task_create_background_characteristics.py
+++ b/src/create_initial_states/task_create_background_characteristics.py
@@ -27,7 +27,6 @@ _DEPENDENCIES = {
     # py files
     "sid_shared.py": Path(sid.__file__).parent.resolve() / "shared.py",
     "shared.py": SRC / "shared.py",
-    "config.py": SRC / "config.py",
     "create_contact_model_group_ids": SRC
     / "create_initial_states"
     / "create_contact_model_group_ids.py",

--- a/src/plotting/plotting.py
+++ b/src/plotting/plotting.py
@@ -6,7 +6,6 @@ import matplotlib.ticker as ticker
 import numpy as np
 import pandas as pd
 import seaborn as sns
-import sid
 
 from src.calculate_moments import smoothed_outcome_per_hundred_thousand_rki
 from src.config import BLD
@@ -157,37 +156,55 @@ def plot_incidences(
     return fig, ax
 
 
-def plot_share_known_cases(share_known_cases, title):
-    n_groups = share_known_cases.index.get_level_values("age_group_rki").nunique()
-    colors = sid.get_colors("ordered", n_groups)
+def plot_share_known_cases(share_known_cases, title, plot_single_runs=False):
+    colors = [
+        "#4e79a7",  # blue
+        "#76b7b2",  # light blue
+        "#edc948",  # yellow
+        "#f28e2b",  # orange
+        "#e15759",  # red
+        "#b07aa1",  # purple
+    ]
     sns.set_palette(colors)
     fig, ax = plt.subplots(figsize=(10, 5))
 
-    for col in share_known_cases:
-        alpha = 0.6 if col == "mean" else 0.2
-        linewidth = 2.5 if col == "mean" else 1
+    if plot_single_runs:
+        for col in share_known_cases:
+            alpha = 0.6 if col == "mean" else 0.2
+            linewidth = 2.5 if col == "mean" else 1
+            sns.lineplot(
+                data=share_known_cases.reset_index(),
+                x="date",
+                y=col,
+                hue="age_group_rki",
+                linewidth=linewidth,
+                alpha=alpha,
+            )
+
+        handles, labels = ax.get_legend_handles_labels()
+        # Reduce legend to have each age group only once and move it to below the plot
+        x, y, width, height = 0.0, -0.3, 1, 0.2
+        n_groups = share_known_cases.index.get_level_values("age_group_rki").nunique()
+        ax.legend(
+            handles[:n_groups],
+            labels[:n_groups],
+            loc="upper center",
+            bbox_to_anchor=(x, y, width, height),
+            ncol=n_groups,
+        )
+
+    else:
         sns.lineplot(
             data=share_known_cases.reset_index(),
             x="date",
-            y=col,
+            y="mean",
             hue="age_group_rki",
-            linewidth=linewidth,
-            alpha=alpha,
+            linewidth=2.5,
+            alpha=0.6,
         )
 
     fig, ax = style_plot(fig, ax)
     ax.set_title(title)
-
-    # Reduce the legend to have each age group only once and move it to below the plot
-    x, y, width, height = 0.0, -0.3, 1, 0.2
-    handles, labels = ax.get_legend_handles_labels()
-    ax.legend(
-        handles[:n_groups],
-        labels[:n_groups],
-        loc="upper center",
-        bbox_to_anchor=(x, y, width, height),
-        ncol=n_groups,
-    )
 
     fig.tight_layout()
 

--- a/src/plotting/task_plot_group_share_known_cases.py
+++ b/src/plotting/task_plot_group_share_known_cases.py
@@ -22,7 +22,7 @@ from src.testing.shared import get_piecewise_linear_interpolation
 @pytask.mark.depends_on(
     {
         "group_share_known_cases": create_path_to_initial_group_share_known_cases(
-            "fall_baseline", pd.Timestamp("2020-12-23")
+            "fall_baseline"
         ),
         "rki_age_groups": BLD / "data" / "population_structure" / "age_groups_rki.pkl",
         "params": BLD / "params.pkl",

--- a/src/plotting/task_plot_group_share_known_cases.py
+++ b/src/plotting/task_plot_group_share_known_cases.py
@@ -31,7 +31,6 @@ from src.testing.shared import get_piecewise_linear_interpolation
         / "create_initial_conditions.py",
         "scenario_config.py": SRC / "simulation" / "scenario_config.py",
         "plotting.py": SRC / "plotting" / "plotting.py",
-        "config.py": SRC / "config.py",
         "testing_shared.py": SRC / "testing" / "shared.py",
     }
 )

--- a/src/plotting/task_plot_incidences_by_group.py
+++ b/src/plotting/task_plot_incidences_by_group.py
@@ -6,7 +6,6 @@ import numpy as np
 import pandas as pd
 import pytask
 import seaborn as sns
-import sid
 
 from src.calculate_moments import smoothed_outcome_per_hundred_thousand_rki
 from src.config import BLD
@@ -101,12 +100,10 @@ def _plot_group_incidence(incidences, title, rki):
     n_rows = int(np.ceil(len(groups) / 2))
     fig, axes = plt.subplots(figsize=(12, n_rows * 3), nrows=n_rows, ncols=2)
     axes = axes.flatten()
-    sid_blue = sid.get_colors("categorical", 5)[0]
     for group, ax in zip(groups, axes):
         plot_incidences(
             incidences={group: incidences.loc[group]},
             title=title.format(group=group),
-            colors=[sid_blue],
             name_to_label={group: "simulated"},
             rki=False,
             plot_scenario_start=False,

--- a/src/plotting/task_plot_incidences_by_group.py
+++ b/src/plotting/task_plot_incidences_by_group.py
@@ -100,13 +100,27 @@ def _plot_group_incidence(incidences, title, rki):
     n_rows = int(np.ceil(len(groups) / 2))
     fig, axes = plt.subplots(figsize=(12, n_rows * 3), nrows=n_rows, ncols=2)
     axes = axes.flatten()
+
+    if "0-4" in groups:
+        colors = [
+            "#C89D64",
+            "#F1B05D",
+            "#EE8445",
+            "#c87259",
+            "#6c4a4d",
+            "#3C2030",
+        ]
+    else:
+        colors = ["#C89D64"] * len(groups)
+
     for group, ax in zip(groups, axes):
         plot_incidences(
             incidences={group: incidences.loc[group]},
             title=title.format(group=group),
             name_to_label={group: "simulated"},
             rki=False,
-            plot_scenario_start=False,
+            colors=colors,
+            scenario_starts=None,
             fig=fig,
             ax=ax,
         )

--- a/src/plotting/task_plot_incidences_by_group.py
+++ b/src/plotting/task_plot_incidences_by_group.py
@@ -21,7 +21,6 @@ from src.simulation.scenario_config import get_named_scenarios
 
 _DEPENDENCIES = {
     "calculate_moments.py": SRC / "calculate_moments.py",
-    "config.py": SRC / "config.py",
     "plotting.py": SRC / "plotting" / "plotting.py",
     "scenario_config.py": SRC / "simulation" / "scenario_config.py",
 }

--- a/src/plotting/task_plot_scenario_comparisons.py
+++ b/src/plotting/task_plot_scenario_comparisons.py
@@ -28,70 +28,40 @@ PLOTS = {
         "scenario_starts": None,
         "colors": [SID_BLUE],
     },
-    "effect_of_vaccines": {
-        "title": "{outcome} in Different Vaccine Scenarios",
-        "scenarios": [
-            "summer_baseline",
-            "spring_without_vaccines",
-            "spring_with_more_vaccines",
-        ],
-        "scenario_starts": [
-            (pd.Timestamp("2021-02-15"), "vaccine stop"),
-            (pd.Timestamp("2021-04-06"), "start increased vaccinations"),
-        ],
-        "colors": [SID_BLUE, "steelblue", "dodgerblue"],
-    },
     "effect_of_rapid_tests": {
-        "title": "{outcome} in Different Rapid Test Scenarios",
+        "title": "Decomposing the Effect of Rapid Tests on {outcome}",
         "scenarios": [
-            "summer_baseline",
+            "spring_baseline",
             "spring_without_rapid_tests",
             "spring_without_work_rapid_tests",
             "spring_without_school_rapid_tests",
-            "spring_with_mandatory_work_rapid_tests",
         ],
         "scenario_starts": None,
         "colors": None,
     },
-    "vaccines_vs_rapid_tests": {
-        "title": "The Effect of Vaccines on {outcome} Compared to Rapid Tests",
+    "explaining_the_decline": {
+        "title": "Explaining the Puzzling Decline in {outcome}",
         "scenarios": [
-            "summer_baseline",
-            # vaccines
+            "spring_baseline",
             "spring_without_vaccines",
-            "spring_with_more_vaccines",
-            # rapid tests
             "spring_without_rapid_tests",
-            "spring_with_mandatory_work_rapid_tests",
-            # neither nor
             "spring_without_rapid_tests_and_no_vaccinations",
+            # "spring_without_seasonality",
         ],
-        "scenario_starts": None,
+        "scenario_starts": [
+            (pd.Timestamp("2021-02-10"), "vaccine stop"),
+            (pd.Timestamp("2021-04-06"), "start of increased vaccinations"),
+        ],
         "colors": None,
     },
+    # --------------------------------------------------------------
     "school_scenarios": {
-        "title": "{outcome} in Different School Scenarios",
+        "title": "The Effect of Schools on {outcome}",
         "scenarios": [
-            "summer_baseline",
-            "spring_emergency_care_after_easter_without_school_rapid_tests",
-            # different test scenarios
+            "spring_baseline",
             "spring_educ_open_after_easter_without_tests",
             "spring_educ_open_after_easter_with_normal_tests",
-            "spring_open_educ_after_easter_with_tests_every_other_day",
-            "spring_open_educ_after_easter_with_daily_tests",
-        ],
-        "scenario_starts": None,
-        "colors": None,
-    },
-    "summer": {
-        "title": "Summer Prediction for {outcome}",
-        "scenarios": [
-            "summer_baseline",
-            "summer_educ_open",
-            "summer_reduced_test_demand",
-            "summer_strict_home_office",
-            "summer_optimistic_vaccinations",
-            "summer_more_rapid_tests_at_work",
+            "spring_emergency_care_after_easter_without_school_rapid_tests",
         ],
         "scenario_starts": None,
         "colors": None,

--- a/src/plotting/task_plot_scenario_comparisons.py
+++ b/src/plotting/task_plot_scenario_comparisons.py
@@ -63,6 +63,8 @@ PLOTS = {
             # rapid tests
             "spring_without_rapid_tests",
             "spring_with_mandatory_work_rapid_tests",
+            # neither nor
+            "spring_without_rapid_tests_and_no_vaccinations",
         ],
         "scenario_starts": None,
         "colors": None,

--- a/src/plotting/task_plot_scenario_comparisons.py
+++ b/src/plotting/task_plot_scenario_comparisons.py
@@ -89,6 +89,17 @@ PLOTS = {
         "colors": [BLUE, GREEN, RED],
         "plot_start": None,
     },
+    "illustrate_rapid_tests": {
+        "title": "Illustrate the effect of rapid tests on {outcome}",
+        "scenarios": [
+            "spring_baseline",
+            "spring_without_rapid_tests",
+            "spring_start_all_rapid_tests_after_easter",
+        ],
+        "scenario_starts": ([(AFTER_EASTER, "Easter")]),
+        "colors": [BLUE, PURPLE, RED],
+        "plot_start": None,
+    },
 }
 """Dict[str, Dict[str, str]]: A dictionary containing the plots to create.
 

--- a/src/plotting/task_plot_scenario_comparisons.py
+++ b/src/plotting/task_plot_scenario_comparisons.py
@@ -49,12 +49,9 @@ PLOTS = {
             "spring_without_seasonality",
             "spring_without_rapid_tests_without_vaccinations_without_seasonality",
         ],
-        "scenario_starts": [
-            (pd.Timestamp("2021-04-06"), "start of increased vaccinations"),
-        ],
+        "scenario_starts": None,
         "colors": None,
     },
-    # --------------------------------------------------------------
     "school_scenarios": {
         "title": "The Effect of Schools on {outcome}",
         "scenarios": [
@@ -64,6 +61,20 @@ PLOTS = {
             "spring_emergency_care_after_easter_without_school_rapid_tests",
         ],
         "scenario_starts": None,
+        "colors": None,
+    },
+    "vaccine_scenarios": {
+        "title": "Effect of Different Vaccination Scenarios on {outcome}",
+        "scenarios": [
+            "baseline",
+            "spring_vaccinate_1_pct_per_day_after_easter",
+            "spring_without_vaccines",
+        ],
+        "scenario_starts": (
+            [
+                (pd.Timestamp("2021-04-06"), "start of increased vaccinations"),
+            ]
+        ),
         "colors": None,
     },
 }

--- a/src/plotting/task_plot_scenario_comparisons.py
+++ b/src/plotting/task_plot_scenario_comparisons.py
@@ -66,7 +66,7 @@ PLOTS = {
     "vaccine_scenarios": {
         "title": "Effect of Different Vaccination Scenarios on {outcome}",
         "scenarios": [
-            "baseline",
+            "spring_baseline",
             "spring_vaccinate_1_pct_per_day_after_easter",
             "spring_without_vaccines",
         ],

--- a/src/plotting/task_plot_scenario_comparisons.py
+++ b/src/plotting/task_plot_scenario_comparisons.py
@@ -74,7 +74,7 @@ PLOTS = {
             "spring_baseline",
             "spring_emergency_care_after_easter_without_school_rapid_tests",
         ],
-        "scenario_starts": None,
+        "scenario_starts": [(AFTER_EASTER, "Easter")],
         "colors": [RED, YELLOW, BLUE, GREEN],
         "plot_start": AFTER_EASTER,
     },

--- a/src/plotting/task_plot_scenario_comparisons.py
+++ b/src/plotting/task_plot_scenario_comparisons.py
@@ -13,7 +13,6 @@ from src.simulation.scenario_config import get_available_scenarios
 from src.simulation.scenario_config import get_named_scenarios
 
 _MODULE_DEPENDENCIES = {
-    "config.py": SRC / "config.py",
     "plotting.py": SRC / "plotting" / "plotting.py",
     "policy_tools.py": SRC / "policies" / "policy_tools.py",
     "scenario_config.py": SRC / "simulation" / "scenario_config.py",

--- a/src/plotting/task_plot_scenario_comparisons.py
+++ b/src/plotting/task_plot_scenario_comparisons.py
@@ -46,10 +46,10 @@ PLOTS = {
             "spring_without_vaccines",
             "spring_without_rapid_tests",
             "spring_without_rapid_tests_and_no_vaccinations",
-            # "spring_without_seasonality",
+            "spring_without_seasonality",
+            "spring_without_rapid_tests_without_vaccinations_without_seasonality",
         ],
         "scenario_starts": [
-            (pd.Timestamp("2021-02-10"), "vaccine stop"),
             (pd.Timestamp("2021-04-06"), "start of increased vaccinations"),
         ],
         "colors": None,
@@ -95,14 +95,21 @@ def create_parametrization(plots, named_scenarios, fast_flag, outcomes):
     for outcome in outcomes:
         for comparison_name, plot_info in plots.items():
             title = plot_info["title"]
-            to_compare = sorted(
-                set(available_scenarios).intersection(plot_info["scenarios"])
-            )
+
+            # need to keep the right colors
+            scenarios = []
+            colors = [] if plot_info["colors"] is not None else None
+            for i, name in enumerate(plot_info["scenarios"]):
+                if name in available_scenarios:
+                    scenarios.append(name)
+                    if colors is not None:
+                        colors.append(plot_info["colors"][i])
+
             depends_on = {
                 scenario_name: create_path_to_weekly_outcome_of_scenario(
                     name=scenario_name, entry=outcome
                 )
-                for scenario_name in to_compare
+                for scenario_name in scenarios
             }
 
             missing_scenarios = set(depends_on) - set(named_scenarios)
@@ -119,7 +126,7 @@ def create_parametrization(plots, named_scenarios, fast_flag, outcomes):
                         depends_on,
                         outcome,
                         title,
-                        plot_info["colors"],
+                        colors,
                         plot_info["scenario_starts"],
                         produces,
                     )

--- a/src/plotting/task_plot_share_known_cases.py
+++ b/src/plotting/task_plot_share_known_cases.py
@@ -12,7 +12,6 @@ from src.simulation.scenario_config import get_available_scenarios
 from src.simulation.scenario_config import get_named_scenarios
 
 _MODULE_DEPENDENCIES = {
-    "config.py": SRC / "config.py",
     "plotting.py": SRC / "plotting" / "plotting.py",
     "scenario_config.py": SRC / "simulation" / "scenario_config.py",
 }

--- a/src/plotting/task_plot_share_known_cases.py
+++ b/src/plotting/task_plot_share_known_cases.py
@@ -4,7 +4,6 @@ import pandas as pd
 import pytask
 
 from src.config import SRC
-from src.config import SUMMER_SCENARIO_START
 from src.plotting.plotting import plot_share_known_cases
 from src.simulation.scenario_config import create_path_to_share_known_cases_of_scenario
 from src.simulation.scenario_config import create_path_to_share_known_cases_plot
@@ -40,12 +39,5 @@ _SIGNATURE, _PARAMETRIZATION = _create_parametrization()
 def task_plot_share_known_cases_per_scenario(depends_on, title, produces):
     share_known_cases = pd.read_pickle(depends_on[0])
     fig, ax = plot_share_known_cases(share_known_cases, title)
-    if "summer" in title.lower():
-        ax.axvline(
-            pd.Timestamp(SUMMER_SCENARIO_START),
-            label="scenario start",
-            color="darkgrey",
-        )
-
     fig.savefig(produces)
     plt.close()

--- a/src/plotting/task_plot_spring_incidences.py
+++ b/src/plotting/task_plot_spring_incidences.py
@@ -12,7 +12,6 @@ from src.plotting.plotting import style_plot
 @pytask.mark.depends_on(
     {
         "rki": BLD / "data" / "processed_time_series" / "rki.pkl",
-        "config.py": SRC / "config.py",
         "plotting.py": SRC / "plotting" / "plotting.py",
     }
 )

--- a/src/policies/task_create_work_multiplier_series.py
+++ b/src/policies/task_create_work_multiplier_series.py
@@ -22,7 +22,6 @@ from src.config import SRC
     {
         "mobility_data": BLD / "data" / "raw_time_series" / "google_mobility.zip",
         "hygiene_data": SRC / "original_data" / "cosmo_hygiene_2021-01-28.csv",
-        "config.py": SRC / "config.py",
     }
 )
 @pytask.mark.produces(

--- a/src/policies/task_visualize_work_multipliers.py
+++ b/src/policies/task_visualize_work_multipliers.py
@@ -22,7 +22,6 @@ plt.rcParams.update(
         "hygiene": BLD / "policies" / "hygiene_score.csv",
         "work": BLD / "policies" / "work_multiplier.csv",
         "plotting.py": SRC / "plotting" / "plotting.py",
-        "config.py": SRC / "config.py",
     }
 )
 @pytask.mark.produces(

--- a/src/prepare_data/task_plot_seasonality.py
+++ b/src/prepare_data/task_plot_seasonality.py
@@ -9,7 +9,6 @@ from src.plotting.plotting import style_plot
 from src.simulation.seasonality import create_seasonality_series
 
 _MODULE_DEPENDENCIES = {
-    "config.py": SRC / "config.py",
     "plotting.py": SRC / "plotting" / "plotting.py",
     "seasonality.py": SRC / "simulation" / "seasonality.py",
 }

--- a/src/prepare_data/task_plot_virus_variant_data.py
+++ b/src/prepare_data/task_plot_virus_variant_data.py
@@ -11,7 +11,6 @@ from src.prepare_data.task_prepare_virus_variant_data import STRAIN_FILES
 
 _MODULE_DEPENDENCIES = {
     "plotting.py": SRC / "plotting" / "plotting.py",
-    "config.py": SRC / "config.py",
 }
 
 

--- a/src/prepare_data/task_prepare_age_data.py
+++ b/src/prepare_data/task_prepare_age_data.py
@@ -10,7 +10,6 @@ from src.shared import create_age_groups_rki
     {
         "data": SRC / "original_data" / "population_structure" / "altersjahre.csv",
         "shared.py": SRC / "shared.py",
-        "config.py": SRC / "config.py",
     }
 )
 @pytask.mark.produces(

--- a/src/prepare_data/task_prepare_eu_data.py
+++ b/src/prepare_data/task_prepare_eu_data.py
@@ -15,7 +15,6 @@ from src.config import SRC
         / "original_data"
         / "population_structure"
         / "eu_age_structure.tsv.gz",
-        "config.py": SRC / "config.py",
     }
 )
 @pytask.mark.produces(BLD / "data" / "population_structure" / "eu_age_structure.pkl")

--- a/src/prepare_data/task_prepare_mossong_data.py
+++ b/src/prepare_data/task_prepare_mossong_data.py
@@ -35,7 +35,6 @@ MOSSONG_OUT = BLD / "data" / "mossong_2008"
         / "population_structure"
         / "eu_hh_size_shares.pkl",
         "shared.py": SRC / "shared.py",
-        "config.py": SRC / "config.py",
     }
 )
 @pytask.mark.produces(

--- a/src/prepare_data/task_prepare_vacations.py
+++ b/src/prepare_data/task_prepare_vacations.py
@@ -52,7 +52,6 @@ def _convert_to_params_format(df):
     {
         "data": SRC / "original_data" / "vacations" / "vacations_2020.xlsx",
         "shared.py": SRC / "shared.py",
-        "config.py": SRC / "config.py",
     }
 )
 @pytask.mark.produces(BLD / "data" / "vacations.pkl")

--- a/src/prepare_data/task_prepare_vaccination_data.py
+++ b/src/prepare_data/task_prepare_vaccination_data.py
@@ -26,7 +26,6 @@ OUT_PATH = BLD / "data" / "vaccinations"
     {
         "data": BLD / "data" / "raw_time_series" / "vaccinations.xlsx",
         "plotting.py": SRC / "plotting" / "plotting.py",
-        "config.py": SRC / "config.py",
     }
 )
 @pytask.mark.produces(

--- a/src/prepare_data/task_prepare_virus_variant_data.py
+++ b/src/prepare_data/task_prepare_virus_variant_data.py
@@ -23,7 +23,6 @@ STRAIN_FILES = {
         "rki": SRC / "original_data" / "virus_strains_rki.csv",
         "cologne": SRC / "original_data" / "virus_strains_cologne.csv",
         "testing_shared.py": SRC / "testing" / "shared.py",
-        "config.py": SRC / "config.py",
     }
 )
 @pytask.mark.produces(STRAIN_FILES)

--- a/src/prepare_data/task_prepare_work_shares.py
+++ b/src/prepare_data/task_prepare_work_shares.py
@@ -41,7 +41,6 @@ def interval_age_group(x):
         / "original_data"
         / "population_structure"
         / "share_working_by_gender_2018.csv",
-        "config.py": SRC / "config.py",
     }
 )
 @pytask.mark.produces(BLD / "data" / "population_structure" / "working_shares.pkl")

--- a/src/simulation/load_simulation_inputs.py
+++ b/src/simulation/load_simulation_inputs.py
@@ -272,7 +272,6 @@ def get_simulation_dependencies(debug):
         "scenario_config.py": SRC / "simulation" / "scenario_config.py",
         "testing_shared.py": SRC / "testing" / "shared.py",
         "policy_tools.py": SRC / "policies" / "policy_tools.py",
-        "config.py": SRC / "config.py",
     }
 
     return out

--- a/src/simulation/params_scenarios.py
+++ b/src/simulation/params_scenarios.py
@@ -172,3 +172,16 @@ def _rapid_test_with_fixed_compliance_after_date(params, change_date, new_val):
         params=params, change_date=change_date, new_val=new_val, loc=loc
     )
     return params
+
+
+def no_seasonality(params):
+    """Set the seasonality to 1 everywhere.
+
+    This induces a jump in the seasonality compared to scenarios with seasonality almost
+    everywhere.
+
+    """
+    params = params.copy(deep=True)
+    params.loc[("seasonality_effect", "seasonality_effect", "weak"), "value"] = 0.0
+    params.loc[("seasonality_effect", "seasonality_effect", "strong"), "value"] = 0.0
+    return params

--- a/src/simulation/params_scenarios.py
+++ b/src/simulation/params_scenarios.py
@@ -7,6 +7,32 @@ from src.testing.shared import get_piecewise_linear_interpolation
 from src.testing.shared import get_piecewise_linear_interpolation_for_one_day
 
 
+def start_all_rapid_tests_after_easter(params):
+    """Start all rapid tests with full force after Easter instead of fading them in."""
+    to_replace = [
+        "share_workers_receiving_offer",
+        "educ_worker_shares",
+        "student_shares",
+        "hh_member_demand",
+    ]
+    new = params.copy(deep=True)
+
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message="indexing past lexsort depth may impact performance."
+        )
+        for subcat in to_replace:
+            max_val = params.loc[("rapid_test_demand", subcat), "value"].max()
+            new = new.drop(("rapid_test_demand", subcat))
+
+            new.loc[("rapid_test_demand", subcat, "2020-01-01"), "value"] = 0.0
+            new.loc[("rapid_test_demand", subcat, "2021-05-05"), "value"] = 0.0
+            new.loc[("rapid_test_demand", subcat, "2021-05-06"), "value"] = max_val
+            new.loc[("rapid_test_demand", subcat, "2025-12-31"), "value"] = max_val
+
+    return new
+
+
 def reduce_rapid_test_demand_after_summer_scenario_start_by_half(params):
     """Reduce rapid tests of households and workers by half.
 

--- a/src/simulation/scenario_config.py
+++ b/src/simulation/scenario_config.py
@@ -33,7 +33,7 @@ def create_path_to_share_known_cases_plot(name, groupby):
 
 
 def create_path_to_group_incidence_plot(name, outcome, groupby):
-    fig_name = f"{FAST_FLAG}_{outcome}_{name}.png"
+    fig_name = f"{FAST_FLAG}_{name}_{outcome}.png"
     return BLD / "figures" / "incidences_by_group" / groupby / fig_name
 
 
@@ -73,11 +73,6 @@ def get_named_scenarios():
         "end_date": "2021-05-31" if FAST_FLAG != "debug" else "2021-05-01",
     }
 
-    summer_dates = {
-        "start_date": SPRING_START,
-        "end_date": "2021-05-31" if FAST_FLAG != "debug" else "2021-06-01",
-    }
-
     named_scenarios = {
         # Baseline Scenarios
         "fall_baseline": {
@@ -87,11 +82,11 @@ def get_named_scenarios():
             "end_date": "2020-12-23",
             "n_seeds": n_baseline_seeds,
         },
-        "summer_baseline": {
+        "spring_baseline": {
             "sim_input_scenario": "baseline",
             "params_scenario": "baseline",
             "n_seeds": n_baseline_seeds,
-            **summer_dates,
+            **spring_dates,
         },
         # Policy Scenarios
         "spring_without_vaccines": {
@@ -130,16 +125,6 @@ def get_named_scenarios():
             "n_seeds": n_side_scenario_seeds,
             **spring_dates,
         },
-        # Note this scenario does still assume that only 70% of employers comply, i.e.
-        # it ensures that 70% of workers get regularly tested. Given that the share of
-        # workers accepting a rapid test from their employer is time invariant this also
-        # means that before Easter there is already a lot more testing going on.
-        "spring_with_mandatory_work_rapid_tests": {
-            "sim_input_scenario": "baseline",
-            "params_scenario": "obligatory_rapid_tests_for_employees",
-            "n_seeds": n_side_scenario_seeds,
-            **spring_dates,
-        },
         # Rapid Tests vs School Closures
         "spring_emergency_care_after_easter_without_school_rapid_tests": {
             "sim_input_scenario": "only_strict_emergency_care_after_april_5",
@@ -162,49 +147,6 @@ def get_named_scenarios():
             "params_scenario": "no_rapid_tests_at_schools",
             "n_seeds": n_main_scenario_seeds,
             **spring_dates,
-        },
-        "spring_open_educ_after_easter_with_tests_every_other_day": {
-            "sim_input_scenario": "open_all_educ_after_easter",
-            "params_scenario": "rapid_tests_at_school_every_other_day_after_april_5",
-            "n_seeds": n_side_scenario_seeds,
-            **spring_dates,
-        },
-        "spring_open_educ_after_easter_with_daily_tests": {
-            "sim_input_scenario": "open_all_educ_after_easter",
-            "params_scenario": "rapid_tests_at_school_every_day_after_april_5",
-            "n_seeds": n_side_scenario_seeds,
-            **spring_dates,
-        },
-        # Summer Scenarios
-        "summer_educ_open": {
-            "sim_input_scenario": "open_all_educ_after_summer_scenario_start",
-            "params_scenario": "baseline",
-            "n_seeds": 0,
-            **summer_dates,
-        },
-        "summer_reduced_test_demand": {
-            "sim_input_scenario": "baseline",
-            "params_scenario": "reduce_rapid_test_demand_after_summer_scenario_start_by_half",  # noqa: E501
-            "n_seeds": 0,
-            **summer_dates,
-        },
-        "summer_strict_home_office": {
-            "sim_input_scenario": "strict_home_office_after_summer_scenario_start",
-            "params_scenario": "baseline",
-            "n_seeds": 0,
-            **summer_dates,
-        },
-        "summer_more_rapid_tests_at_work": {
-            "sim_input_scenario": "baseline",
-            "params_scenario": "rapid_test_with_90pct_compliance_after_summer_scenario_start",  # noqa: E501
-            "n_seeds": 0,
-            **summer_dates,
-        },
-        "summer_optimistic_vaccinations": {
-            "sim_input_scenario": "vaccinations_after_summer_scenario_start_as_on_strongest_week_day",  # noqa: E501
-            "params_scenario": "baseline",
-            "n_seeds": 0,
-            **summer_dates,
         },
     }
     return named_scenarios

--- a/src/simulation/scenario_config.py
+++ b/src/simulation/scenario_config.py
@@ -137,6 +137,12 @@ def get_named_scenarios():
             "n_seeds": n_main_scenario_seeds,
             **spring_dates,
         },
+        "spring_start_all_rapid_tests_after_easter": {
+            "sim_input_scenario": "baseline",
+            "params_scenario": "start_all_rapid_tests_after_easter",
+            "n_seeds": 2,
+            **spring_dates,
+        },
         # Rapid Tests vs School Closures
         "spring_emergency_care_after_easter_without_school_rapid_tests": {
             "sim_input_scenario": "only_strict_emergency_care_after_april_5",

--- a/src/simulation/scenario_config.py
+++ b/src/simulation/scenario_config.py
@@ -89,8 +89,14 @@ def get_named_scenarios():
             **spring_dates,
         },
         # Policy Scenarios
+        "spring_without_seasonality": {
+            "sim_input_scenario": "baseline",
+            "params_scenario": "no_seasonality",
+            "n_seeds": n_side_scenario_seeds,
+            **spring_dates,
+        },
         "spring_without_vaccines": {
-            "sim_input_scenario": "no_vaccinations_after_feb_15",
+            "sim_input_scenario": "no_vaccinations_after_feb_10",
             "params_scenario": "baseline",
             "n_seeds": n_main_scenario_seeds,
             **spring_dates,
@@ -120,9 +126,15 @@ def get_named_scenarios():
             **spring_dates,
         },
         "spring_without_rapid_tests_and_no_vaccinations": {
-            "sim_input_scenario": "no_rapid_tests_and_no_vaccinations_after_feb_15",
+            "sim_input_scenario": "no_rapid_tests_and_no_vaccinations_after_feb_10",
             "params_scenario": "baseline",
             "n_seeds": n_side_scenario_seeds,
+            **spring_dates,
+        },
+        "spring_without_rapid_tests_without_vaccinations_without_seasonality": {
+            "sim_input_scenario": "no_rapid_tests_and_no_vaccinations_after_feb_10",
+            "params_scenario": "no_seasonality",
+            "n_seeds": n_main_scenario_seeds,
             **spring_dates,
         },
         # Rapid Tests vs School Closures

--- a/src/simulation/scenario_config.py
+++ b/src/simulation/scenario_config.py
@@ -124,6 +124,12 @@ def get_named_scenarios():
             "n_seeds": n_side_scenario_seeds,
             **spring_dates,
         },
+        "spring_without_rapid_tests_and_no_vaccinations": {
+            "sim_input_scenario": "no_rapid_tests_and_no_vaccinations_after_feb_15",
+            "params_scenario": "baseline",
+            "n_seeds": n_side_scenario_seeds,
+            **spring_dates,
+        },
         # Note this scenario does still assume that only 70% of employers comply, i.e.
         # it ensures that 70% of workers get regularly tested. Given that the share of
         # workers accepting a rapid test from their employer is time invariant this also

--- a/src/simulation/scenario_config.py
+++ b/src/simulation/scenario_config.py
@@ -10,8 +10,8 @@ def create_path_to_period_outputs_of_simulation(name, seed):
     return path
 
 
-def create_path_to_initial_group_share_known_cases(name, date):
-    file_name = f"{FAST_FLAG}_{name}_for_{date.date()}.pkl"
+def create_path_to_initial_group_share_known_cases(name):
+    file_name = f"{FAST_FLAG}_{name}.pkl"
     return BLD / "simulations" / "share_known_case_prediction" / file_name
 
 
@@ -145,9 +145,15 @@ def get_named_scenarios():
         # large enough to allow the same fraction of individuals that should be tested
         # is actually tested. After Easter that was 95% for educ workers and 75% for
         # school pupils and increases from there to 1 for pupils.
-        "spring_educ_open_after_easter": {
+        "spring_educ_open_after_easter_with_normal_tests": {
             "sim_input_scenario": "open_all_educ_after_easter",
             "params_scenario": "baseline",
+            "n_seeds": n_main_scenario_seeds,
+            **spring_dates,
+        },
+        "spring_educ_open_after_easter_without_tests": {
+            "sim_input_scenario": "open_all_educ_after_easter",
+            "params_scenario": "no_rapid_tests_at_schools",
             "n_seeds": n_main_scenario_seeds,
             **spring_dates,
         },

--- a/src/simulation/scenario_config.py
+++ b/src/simulation/scenario_config.py
@@ -54,10 +54,10 @@ def get_named_scenarios():
         n_baseline_seeds = 1
         n_main_scenario_seeds = 0
         n_side_scenario_seeds = 0
-    elif FAST_FLAG == "verify":  # use 27 cores -> 2 rounds
-        n_baseline_seeds = 4  # 2x
-        n_main_scenario_seeds = 2  # 4x
-        n_side_scenario_seeds = 1  # 11
+    elif FAST_FLAG == "verify":
+        n_baseline_seeds = 4
+        n_main_scenario_seeds = 2
+        n_side_scenario_seeds = 1
     elif FAST_FLAG == "full":
         n_baseline_seeds = 25
         n_main_scenario_seeds = 25
@@ -101,8 +101,8 @@ def get_named_scenarios():
             "n_seeds": n_main_scenario_seeds,
             **spring_dates,
         },
-        "spring_with_more_vaccines": {
-            "sim_input_scenario": "vaccinations_after_easter_as_on_strongest_week_day",
+        "spring_vaccinate_1_pct_per_day_after_easter": {
+            "sim_input_scenario": "vaccinate_1_pct_per_day_after_easter",
             "params_scenario": "baseline",
             "n_seeds": n_side_scenario_seeds,
             **spring_dates,

--- a/src/simulation/scenario_simulation_inputs.py
+++ b/src/simulation/scenario_simulation_inputs.py
@@ -265,6 +265,36 @@ def vaccinations_after_easter_as_on_strongest_week_day(paths, fixed_inputs):
     return scenario_inputs
 
 
+def vaccinate_1_pct_per_day_after_easter(paths, fixed_inputs):
+    """Increase the vaccination rate to 1% per day.
+
+    There were 3 days on which this many people were vaccinated before May 26.
+
+    This abstracts from possible constraints on the amount of available doses.
+
+    """
+    start_date = fixed_inputs["duration"]["start"]
+    init_start = start_date - pd.Timedelta(31, unit="D")
+
+    vaccination_shares = pd.read_pickle(paths["vaccination_shares"])
+    vaccination_models = _get_vaccination_model_with_new_value_after_date(
+        vaccination_shares,
+        init_start,
+        change_date="2021-04-06",  # Tuesday after Easter Monday
+        new_val=0.01,
+        model_name="highest_vacc_share_after_easter",
+    )
+    scenario_inputs = {
+        "vaccination_models": vaccination_models,
+        "contact_policies": _baseline_policies(fixed_inputs),
+        "rapid_test_models": _baseline_rapid_test_models(fixed_inputs),
+        "rapid_test_reaction_models": _baseline_rapid_test_reaction_models(
+            fixed_inputs
+        ),
+    }
+    return scenario_inputs
+
+
 def _get_vaccination_model_with_new_value_after_date(
     vaccination_shares, init_start, change_date, new_val, model_name
 ):

--- a/src/simulation/scenario_simulation_inputs.py
+++ b/src/simulation/scenario_simulation_inputs.py
@@ -186,6 +186,13 @@ def no_vaccinations_after_feb_15(paths, fixed_inputs):
     return scenario_inputs
 
 
+def no_rapid_tests_and_no_vaccinations_after_feb_15(paths, fixed_inputs):
+    out = no_vaccinations_after_feb_15(paths, fixed_inputs)
+    out["rapid_test_models"] = None
+    out["rapid_test_reaction_models"] = None
+    return out
+
+
 def vaccinations_after_summer_scenario_start_as_on_strongest_week_day(
     paths, fixed_inputs
 ):

--- a/src/simulation/scenario_simulation_inputs.py
+++ b/src/simulation/scenario_simulation_inputs.py
@@ -163,7 +163,7 @@ def no_rapid_tests(paths, fixed_inputs):
     return out
 
 
-def no_vaccinations_after_feb_15(paths, fixed_inputs):
+def no_vaccinations_after_feb_10(paths, fixed_inputs):
     start_date = fixed_inputs["duration"]["start"]
     init_start = start_date - pd.Timedelta(31, unit="D")
 
@@ -171,9 +171,9 @@ def no_vaccinations_after_feb_15(paths, fixed_inputs):
     vaccination_models = _get_vaccination_model_with_new_value_after_date(
         vaccination_shares,
         init_start,
-        change_date="2021-02-15",
+        change_date="2021-02-10",
         new_val=0,
-        model_name="only_vaccinate_until_feb_15",
+        model_name="only_vaccinate_until_feb_10",
     )
     scenario_inputs = {
         "vaccination_models": vaccination_models,
@@ -186,8 +186,8 @@ def no_vaccinations_after_feb_15(paths, fixed_inputs):
     return scenario_inputs
 
 
-def no_rapid_tests_and_no_vaccinations_after_feb_15(paths, fixed_inputs):
-    out = no_vaccinations_after_feb_15(paths, fixed_inputs)
+def no_rapid_tests_and_no_vaccinations_after_feb_10(paths, fixed_inputs):
+    out = no_vaccinations_after_feb_10(paths, fixed_inputs)
     out["rapid_test_models"] = None
     out["rapid_test_reaction_models"] = None
     return out

--- a/src/simulation/scenario_simulation_inputs.py
+++ b/src/simulation/scenario_simulation_inputs.py
@@ -282,7 +282,7 @@ def vaccinate_1_pct_per_day_after_easter(paths, fixed_inputs):
         init_start,
         change_date="2021-04-06",  # Tuesday after Easter Monday
         new_val=0.01,
-        model_name="highest_vacc_share_after_easter",
+        model_name="vaccinate_1_pct_per_day_after_easter",
     )
     scenario_inputs = {
         "vaccination_models": vaccination_models,

--- a/src/simulation/task_create_initial_group_share_known_cases.py
+++ b/src/simulation/task_create_initial_group_share_known_cases.py
@@ -6,36 +6,24 @@ from src.simulation.scenario_config import (
     create_path_to_initial_group_share_known_cases,
 )
 from src.simulation.scenario_config import create_path_to_share_known_cases_of_scenario
-from src.simulation.scenario_config import get_named_scenarios
 
-_MODULE_DEPENDENCIES = {
+_DEPENDENCIES = {
     "scenario_config.py": SRC / "simulation" / "scenario_config.py",
-    "config.py": SRC / "config.py",
+    "snk": create_path_to_share_known_cases_of_scenario("fall_baseline"),
 }
 
 
-def _create_parametrization():
-    named_scenarios = get_named_scenarios()
-    parametrization = []
-    for name, spec in named_scenarios.items():
-        if "baseline" in name:
-            depends_on = {"snk": create_path_to_share_known_cases_of_scenario(name)}
-            date = pd.Timestamp(spec["end_date"])
-            produces = create_path_to_initial_group_share_known_cases(name, date)
-            parametrization.append((depends_on, date, produces))
-    return "depends_on, date, produces", parametrization
-
-
-_SIGNATURE, _PARAMETRIZATION = _create_parametrization()
-
-
-@pytask.mark.parametrize(_SIGNATURE, _PARAMETRIZATION)
-def task_create_initial_group_share_known_cases(depends_on, date, produces):
+@pytask.mark.depends_on(_DEPENDENCIES)
+@pytask.mark.produces(create_path_to_initial_group_share_known_cases("fall_baseline"))
+def task_create_initial_group_share_known_cases(depends_on, produces):
     share_known_cases = pd.read_pickle(depends_on["snk"])
     share_known_cases = share_known_cases["mean"]
     share_known_cases = share_known_cases.unstack()
 
     len_interval = pd.Timedelta(days=28)
-    dates = pd.date_range(date - len_interval, date)
+    first_date = share_known_cases.index.min()
+    last_date = share_known_cases.index.max()
+    start_date = max(last_date - len_interval, first_date)
+    dates = pd.date_range(start_date, last_date)
     avg_group_share_known_cases = share_known_cases.loc[dates].mean(axis=0)
     avg_group_share_known_cases.to_pickle(produces)

--- a/src/simulation/task_process_simulation_outputs.py
+++ b/src/simulation/task_process_simulation_outputs.py
@@ -15,7 +15,6 @@ _MODULE_DEPENDENCIES = {
     "calculate_moments.py": SRC / "calculate_moments.py",
     "load_simulation_inputs.py": SRC / "simulation" / "load_simulation_inputs.py",
     "scenario_config.py": SRC / "simulation" / "scenario_config.py",
-    "config.py": SRC / "config.py",
 }
 
 

--- a/src/simulation/task_run_simulation.py
+++ b/src/simulation/task_run_simulation.py
@@ -23,14 +23,11 @@ def _create_simulation_parametrization():
     """
     named_scenarios = get_named_scenarios()
     common_dependencies = get_simulation_dependencies(debug=FAST_FLAG == "debug")
-    fall_end_date = pd.Timestamp(named_scenarios["fall_baseline"]["end_date"])
 
     scenarios = []
     for name, specs in named_scenarios.items():
         if pd.Timestamp(specs["start_date"]) > pd.Timestamp("2020-11-01"):
-            skc_path = create_path_to_initial_group_share_known_cases(
-                "fall_baseline", fall_end_date
-            )
+            skc_path = create_path_to_initial_group_share_known_cases("fall_baseline")
             group_share_dependencies = {"group_share_known_case_path": skc_path}
         else:
             group_share_dependencies = {}

--- a/src/testing/rapid_test_reactions.py
+++ b/src/testing/rapid_test_reactions.py
@@ -2,7 +2,7 @@ from pandas.api.types import is_bool_dtype
 
 
 def rapid_test_reactions(states, contacts, params, seed):  # noqa: U100
-    """Make people react to a positive rapid tests"""
+    """Make people react to a positive rapid tests by reducing their contacts."""
     contacts = contacts.copy(deep=True)
 
     # we assume that if you haven't received PCR confirmation within 7 days

--- a/src/testing/task_calculate_share_known_cases.py
+++ b/src/testing/task_calculate_share_known_cases.py
@@ -22,7 +22,6 @@ from src.testing.shared import get_piecewise_linear_interpolation
         / "testing"
         / "detected_and_undetected_infections_new.csv",
         "params": BLD / "params.pkl",
-        "config.py": SRC / "config.py",
         "plotting.py": SRC / "plotting" / "plotting.py",
         "testing_shared.py": SRC / "testing" / "shared.py",
     }

--- a/src/testing/task_get_and_plot_share_of_tests_for_symptomatics.py
+++ b/src/testing/task_get_and_plot_share_of_tests_for_symptomatics.py
@@ -25,7 +25,6 @@ OUT_PATH = BLD / "data" / "testing"
 @pytask.mark.depends_on(
     {
         "data": BLD / "data" / "raw_time_series" / "test_distribution.xlsx",
-        "config.py": SRC / "config.py",
         "plotting.py": SRC / "plotting" / "plotting.py",
         "testing_shared.py": SRC / "testing" / "shared.py",
     }

--- a/src/testing/task_plot_share_of_educ_participants_with_rapid_test.py
+++ b/src/testing/task_plot_share_of_educ_participants_with_rapid_test.py
@@ -14,7 +14,6 @@ from src.testing.shared import get_piecewise_linear_interpolation
 @pytask.mark.depends_on(
     {
         "params": BLD / "params.pkl",
-        "config.py": SRC / "config.py",
         "plotting.py": SRC / "plotting" / "plotting.py",
         "testing_shared.py": SRC / "testing" / "shared.py",
     }

--- a/src/testing/task_plot_share_of_hh_members_demanding_test.py
+++ b/src/testing/task_plot_share_of_hh_members_demanding_test.py
@@ -16,7 +16,6 @@ from src.testing.shared import get_piecewise_linear_interpolation
     {
         "params": BLD / "params.pkl",
         "rki": BLD / "data" / "processed_time_series" / "rki.pkl",
-        "config.py": SRC / "config.py",
         "plotting.py": SRC / "plotting" / "plotting.py",
         "testing_shared.py": SRC / "testing" / "shared.py",
     }

--- a/src/testing/task_plot_share_of_workers_with_test_offer.py
+++ b/src/testing/task_plot_share_of_workers_with_test_offer.py
@@ -14,7 +14,6 @@ from src.testing.shared import get_piecewise_linear_interpolation
 @pytask.mark.depends_on(
     {
         "params": BLD / "params.pkl",
-        "config.py": SRC / "config.py",
         "plotting.py": SRC / "plotting" / "plotting.py",
         "shared.py": SRC / "testing" / "shared.py",
     }


### PR DESCRIPTION
- [x] add scenario with open schools and no tests
- [x] remove src/config dependency from all tasks
- [x] improve titles and colors of scenario comparison pltos
- [x] add scenario without tests and without vaccinations
- [x] reduce scenarios and work on plot specs (**incomplete**)
- [x] add scenarios without seasonality (one off) and with neither seasonality nor vaccinations nor rapid tests
- [x] only plot the mean group share known cases 
- [x] implement and use more optimistic vaccination scenario with 1 percent of the population getting vaccinated each day. 

## Simulations

**Fall**

![image](https://user-images.githubusercontent.com/9567321/119610146-10207100-bdf9-11eb-9523-1edfa5e75c19.png)

**Group Share Known Cases**

![image](https://user-images.githubusercontent.com/9567321/119610468-9341c700-bdf9-11eb-80df-db3beb1bdeec.png)

**Rapid Tests in Spring**

![image](https://user-images.githubusercontent.com/9567321/119610036-e23b2c80-bdf8-11eb-9c4c-a86f82671eec.png)

**Rapid Tests starting directly after Easter**

![image](https://user-images.githubusercontent.com/9567321/119610200-275f5e80-bdf9-11eb-9044-d052f4869a12.png)

**School Scenarios**

![image](https://user-images.githubusercontent.com/9567321/119610356-67264600-bdf9-11eb-9ec8-ddbb72176328.png)

**Vaccination Scenarios**

![image](https://user-images.githubusercontent.com/9567321/119610414-7c9b7000-bdf9-11eb-9a79-4da375e95f04.png)

The effect on the incidences is very small but I verified that more individuals are vaccinated. As of June 1, in the normal scenario 44% are vaccinated, in the 1 percent per day after Easter scenario, it's 69%. 




  