### PR TITLE
Calculate rapid test rates after smoothing and averaging

### DIFF
--- a/src/create_initial_states/task_create_background_characteristics.py
+++ b/src/create_initial_states/task_create_background_characteristics.py
@@ -8,6 +8,7 @@ import sid
 from sid.shared import factorize_assortative_variables
 
 from src.config import BLD
+from src.config import FAST_FLAG
 from src.config import N_HOUSEHOLDS
 from src.config import SRC
 from src.create_initial_states.create_contact_model_group_ids import (
@@ -64,15 +65,13 @@ _DEPENDENCIES = {
     "params": BLD / "params.pkl",
 }
 
+_N_HH_AND_PATH = [(100_000, BLD / "data" / "debug_initial_states.parquet")]
+if FAST_FLAG != "debug":
+    _N_HH_AND_PATH.append((N_HOUSEHOLDS, BLD / "data" / "initial_states.parquet"))
+
 
 @pytask.mark.depends_on(_DEPENDENCIES)
-@pytask.mark.parametrize(
-    "n_hhs, produces",
-    [
-        (N_HOUSEHOLDS, BLD / "data" / "initial_states.parquet"),
-        (100_000, BLD / "data" / "debug_initial_states.parquet"),
-    ],
-)
+@pytask.mark.parametrize("n_hhs, produces", _N_HH_AND_PATH)
 def task_create_initial_states_microcensus(depends_on, n_hhs, produces):
     mc = pd.read_stata(depends_on["hh_data"])
     county_probabilities = pd.read_parquet(depends_on["county_probabilities"])

--- a/src/create_initial_states/task_create_background_characteristics.py
+++ b/src/create_initial_states/task_create_background_characteristics.py
@@ -8,7 +8,6 @@ import sid
 from sid.shared import factorize_assortative_variables
 
 from src.config import BLD
-from src.config import FAST_FLAG
 from src.config import N_HOUSEHOLDS
 from src.config import SRC
 from src.create_initial_states.create_contact_model_group_ids import (
@@ -65,13 +64,15 @@ _DEPENDENCIES = {
     "params": BLD / "params.pkl",
 }
 
-_N_HH_AND_PATH = [(100_000, BLD / "data" / "debug_initial_states.parquet")]
-if FAST_FLAG != "debug":
-    _N_HH_AND_PATH.append((N_HOUSEHOLDS, BLD / "data" / "initial_states.parquet"))
-
 
 @pytask.mark.depends_on(_DEPENDENCIES)
-@pytask.mark.parametrize("n_hhs, produces", _N_HH_AND_PATH)
+@pytask.mark.parametrize(
+    "n_hhs, produces",
+    [
+        (N_HOUSEHOLDS, BLD / "data" / "initial_states.parquet"),
+        (100_000, BLD / "data" / "debug_initial_states.parquet"),
+    ],
+)
 def task_create_initial_states_microcensus(depends_on, n_hhs, produces):
     mc = pd.read_stata(depends_on["hh_data"])
     county_probabilities = pd.read_parquet(depends_on["county_probabilities"])

--- a/src/plotting/task_plot_rapid_test_statistics.py
+++ b/src/plotting/task_plot_rapid_test_statistics.py
@@ -17,6 +17,13 @@ from src.simulation.task_process_rapid_test_statistics import CHANNELS
 from src.simulation.task_process_rapid_test_statistics import OUTCOMES
 from src.simulation.task_process_rapid_test_statistics import SHARE_TYPES
 
+RATES = [
+    "true_positive_rate",
+    "false_positive_rate",
+    "true_negative_rate",
+    "false_negative_rate",
+]
+
 
 def _create_rapid_test_plot_parametrization():
     signature = "depends_on, plot_single_runs, ylabel, produces"
@@ -36,7 +43,7 @@ def _create_rapid_test_plot_parametrization():
         "tested": "tests",
     }
 
-    column_and_label = []
+    column_and_label = [(rate, rate.replace("_", " ")) for rate in RATES]
     for outcome in OUTCOMES:
         for share_type in SHARE_TYPES:
             column = f"{share_type}_{outcome}"

--- a/src/plotting/task_plot_rapid_test_statistics.py
+++ b/src/plotting/task_plot_rapid_test_statistics.py
@@ -15,7 +15,6 @@ from src.simulation.scenario_config import (
 )
 from src.simulation.task_process_rapid_test_statistics import CHANNELS
 from src.simulation.task_process_rapid_test_statistics import OUTCOMES
-from src.simulation.task_process_rapid_test_statistics import RATES
 from src.simulation.task_process_rapid_test_statistics import SHARE_TYPES
 
 
@@ -37,7 +36,7 @@ def _create_rapid_test_plot_parametrization():
         "tested": "tests",
     }
 
-    column_and_label = [(rate, rate.replace("_", " ")) for rate in RATES]
+    column_and_label = []
     for outcome in OUTCOMES:
         for share_type in SHARE_TYPES:
             column = f"{share_type}_{outcome}"

--- a/src/simulation/task_process_rapid_test_statistics.py
+++ b/src/simulation/task_process_rapid_test_statistics.py
@@ -121,7 +121,14 @@ def task_create_rapid_test_statistic_ratios(name, depends_on, produces):
     denominator = pd.read_pickle(depends_on["denominator"])
 
     seeds = list(range(_N_SEEDS))
-    rate_df = numerator[seeds] / denominator[seeds]  # needed for plotting single runs
+    rate_df = pd.DataFrame()
+    # needed for plotting single runs
+    for s in seeds:
+        smooth_num = numerator[s].rolling(window=7, min_periods=1, center=False).mean()
+        smooth_denom = (
+            denominator[s].rolling(window=7, min_periods=1, center=False).mean()
+        )
+        rate_df[s] = smooth_num / smooth_denom
 
     # it's important to first average and smooth and **then** divide to get rid of noise
     # before the division.

--- a/src/testing/create_rapid_test_statistics.py
+++ b/src/testing/create_rapid_test_statistics.py
@@ -65,12 +65,11 @@ def _calculate_rapid_test_statistics_by_channel(
 ):
     """Calculate the rapid test statistics for one channel or overall.
 
-    Naming convention for the denominators:
+        Naming convention for the denominators:
 
-    - testshare             -> n_tests
-    - popshare              -> n_people
-    - number                -> n_people / POPULATION_GERMANY
-    - rate                  -> n_{pos/neg}_tests
+        - testshare             -> n_tests
+        - popshare              -> n_people
+        - number                -> n_people / POPULATION_GERMANY
 
     Args:
         states (pandas.DataFrame): sid states DataFrame.
@@ -112,18 +111,5 @@ def _calculate_rapid_test_statistics_by_channel(
         )
         statistics[f"popshare_{name}_by_{channel_name}"] = sr.sum() / n_obs
         statistics[f"testshare_{name}_by_{channel_name}"] = sr.sum() / n_tested
-
-    statistics[f"true_positive_rate_by_{channel_name}"] = (
-        individual_outcomes["true_positive"].sum() / n_tested_positive
-    )
-    statistics[f"true_negative_rate_by_{channel_name}"] = (
-        individual_outcomes["true_negative"].sum() / n_tested_negative
-    )
-    statistics[f"false_positive_rate_by_{channel_name}"] = (
-        individual_outcomes["false_positive"].sum() / n_tested_positive
-    )
-    statistics[f"false_negative_rate_by_{channel_name}"] = (
-        individual_outcomes["false_negative"].sum() / n_tested_negative
-    )
 
     return statistics

--- a/src/testing/create_rapid_test_statistics.py
+++ b/src/testing/create_rapid_test_statistics.py
@@ -65,7 +65,7 @@ def _calculate_rapid_test_statistics_by_channel(
 ):
     """Calculate the rapid test statistics for one channel or overall.
 
-        Naming convention for the denominators:
+    Naming convention for the denominators:
 
         - testshare             -> n_tests
         - popshare              -> n_people

--- a/src/testing/task_get_and_plot_share_of_tests_for_symptomatics.py
+++ b/src/testing/task_get_and_plot_share_of_tests_for_symptomatics.py
@@ -9,6 +9,7 @@ from src.config import PLOT_END_DATE
 from src.config import PLOT_SIZE
 from src.config import PLOT_START_DATE
 from src.config import SRC
+from src.plotting.plotting import BLUE
 from src.plotting.plotting import style_plot
 from src.testing.shared import convert_weekly_to_daily
 from src.testing.shared import get_date_from_year_and_week
@@ -46,6 +47,11 @@ plt.rcParams.update(
         / "data"
         / "testing"
         / "share_of_pcr_tests_going_to_symptomatics.pdf",
+        "used_share_pcr_going_to_symptomatic": BLD
+        / "figures"
+        / "data"
+        / "testing"
+        / "used_share_of_pcr_tests_going_to_symptomatics.pdf",
     }
 )
 def task_prepare_characteristics_of_the_tested(depends_on, produces):
@@ -105,6 +111,18 @@ def task_prepare_characteristics_of_the_tested(depends_on, produces):
 
     df = df.reset_index().rename(columns={"index": "date"})
     df.to_csv(produces["data"])
+
+    fig, ax = plt.subplots(figsize=PLOT_SIZE)
+    sns.lineplot(
+        x=share_of_tests_for_symptomatics_series.index,
+        y=share_of_tests_for_symptomatics_series,
+        color=BLUE,
+        linewidth=3.0,
+        alpha=0.6,
+    )
+    fig, ax = style_plot(fig, ax)
+    fig.tight_layout()
+    fig.savefig(produces["used_share_pcr_going_to_symptomatic"])
 
 
 def _clean_data(df):

--- a/tests/test_create_rapid_test_statistics.py
+++ b/tests/test_create_rapid_test_statistics.py
@@ -1,4 +1,3 @@
-import numpy as np
 import pandas as pd
 from pandas.testing import assert_series_equal
 
@@ -61,21 +60,6 @@ def test_create_rapid_test_statistics(monkeypatch):
         {
             0: {
                 "date": date,
-                # overall shares
-                "true_positive_rate_by_overall": 0.5,
-                "true_negative_rate_by_overall": 0.5,
-                "false_negative_rate_by_overall": 0.5,
-                "false_positive_rate_by_overall": 0.5,
-                # shares in a
-                "true_positive_rate_by_a": 0.5,
-                "true_negative_rate_by_a": 0.0,
-                "false_negative_rate_by_a": 1.0,
-                "false_positive_rate_by_a": 0.5,
-                # shares in b
-                "true_positive_rate_by_b": np.nan,
-                "true_negative_rate_by_b": 0.5,
-                "false_negative_rate_by_b": 0.5,
-                "false_positive_rate_by_b": np.nan,
                 # numbers
                 "number_false_negative_by_a": 2 * scaling,
                 "number_false_negative_by_b": 2 * scaling,
@@ -197,10 +181,6 @@ def test_calculate_rapid_test_statistics_by_channel():
             "testshare_false_negative_by_channel": 2 / 5,
             "testshare_true_positive_by_channel": 1 / 5,
             "testshare_true_negative_by_channel": 1 / 5,
-            "true_positive_rate_by_channel": 1 / 2,
-            "true_negative_rate_by_channel": 1 / 3,
-            "false_positive_rate_by_channel": 1 / 2,
-            "false_negative_rate_by_channel": 2 / 3,
         }
     )
     assert_series_equal(res.loc[expected.index], expected, check_names=False)


### PR DESCRIPTION
### Current behavior

The rapid test statistics that are based on divisions of other statistics, the so called rates, are created inside the simulation before any smoothing or averaging is done. This is problematic because averaging after dividing is different from dividing after averaging and the latter is much more robust and reduces noise.

### Desired behavior

Only create the rates during the processing step and only divide after smoothing (and averaging for the average). 
