### PR TITLE
Reduce rapid test demand from vaccinated and when incidences are low

### DIFF
--- a/src/create_initial_states/task_build_full_params.py
+++ b/src/create_initial_states/task_build_full_params.py
@@ -103,6 +103,15 @@ def task_create_full_params(depends_on, produces):
     params = _add_educ_rapid_test_fade_in_params(params)
     params = _add_private_rapid_test_demand_fade_in_params(params)
     params = _add_rapid_test_reaction_params(params)
+
+    # these are arbitrary and will have to be estimated.
+    params.loc[
+        ("rapid_test_demand", "low_incidence_factor", "other_demand"), "value"
+    ] = 0.25
+    params.loc[
+        ("rapid_test_demand", "low_incidence_factor", "worker_demand"), "value"
+    ] = 0.25
+
     params = _add_event_params(params)
 
     # seasonality parameter

--- a/src/testing/task_get_and_plot_share_of_tests_for_symptomatics.py
+++ b/src/testing/task_get_and_plot_share_of_tests_for_symptomatics.py
@@ -55,7 +55,7 @@ plt.rcParams.update(
     }
 )
 def task_prepare_characteristics_of_the_tested(depends_on, produces):
-    df = pd.read_excel(depends_on["data"], sheet_name="Klinische_Aspekte", header=1)
+    df = pd.read_excel(depends_on["data"], sheet_name="Klinische_Aspekte", header=2)
 
     df = _clean_data(df)
     df = convert_weekly_to_daily(df.reset_index(), divide_by_7_cols=[])


### PR DESCRIPTION
- [x] fully vaccinated individuals do not test themselves after Easter preemptively (3G rule) 
- [x] when incidences are low individuals get lazy with respect to tests that are not required and not caused by a suspicion to be infected.