### PR TITLE
Different refuser shares for youths

### DIFF
--- a/src/create_initial_states/task_build_full_params.py
+++ b/src/create_initial_states/task_build_full_params.py
@@ -92,7 +92,11 @@ def task_create_full_params(depends_on, produces):
     # 12% are undecided. 8% are opposed to being vaccinated.
     # We assume that 15% will refuse to be vaccinated.
     # source: https://bit.ly/3c9mTgX (publication date: 2021-03-02)
-    params.loc[("vaccinations", "share_refuser", "share_refuser"), "value"] = 0.15
+    params.loc[("vaccinations", "share_refuser", "adult"), "value"] = 0.15
+    # for 12 to 15 year olds, there are more refusers: 44 to 66% are willing to
+    # vaccinate their child (https://bit.ly/3BdHHgJ). Thus, for them the share
+    # of refusers is 34 to 56%
+    params.loc[("vaccinations", "share_refuser", "youth"), "value"] = 0.45
 
     # source: https://bit.ly/3gHlcKd (section 3.5, 2021-03-09, accessed 2021-04-28)
     # 82% say they would get a PCR test after a positive rapid test

--- a/src/policies/find_people_to_vaccinate.py
+++ b/src/policies/find_people_to_vaccinate.py
@@ -1,5 +1,6 @@
 import warnings
 
+import numpy as np
 import pandas as pd
 from sid import get_date
 
@@ -8,37 +9,46 @@ def find_people_to_vaccinate(
     receives_vaccine,  # noqa: U100
     states,
     params,
-    seed,  # noqa: U100
+    seed,
     vaccination_shares,
     init_start,
 ):
     """Find people that have to be vaccinated on a given day.
 
-    On the init_start date all individuals that should have been vaccinated until
-    that day get vaccinated. Since vaccinations take effect within three weeks
-    and the burn in period is four weeks this does not lead to jumps in the
-    simulation period.
+    On the init_start date all individuals that should have been vaccinated
+    until that day get vaccinated. Since vaccinations take effect within three
+    weeks and the burn in period is four weeks this does not lead to jumps in
+    the simulation period.
+
+    On June 7 the vaccination priorization was lifted in Germany. On May 28 the
+    EMA approved the first vaccine for youths from 12 to 15. However, until July
+    15 less than 5% of 12 to 17 year olds were vaccinated and the STIKO only
+    recommended the CoViD vaccine for healthy 12 to 17 year olds in August.
+
+    We model this by vaccinating individuals 12 and older that are not refusers
+    randomly starting on July 15.
+
+    Sources:
+        - https://bit.ly/2WpIegM
+        - https://bit.ly/3zlzIhe
 
     Args:
         states (pandas.DataFrame): States DataFrame that must contain the
-            column vaccination_rank. This column is a float with values
-            between zero and one. Low values mean that people get
-            vaccinated early.
-        params (pandas.DataFrame): not used.
-        seed (int): not used.
-        vaccination_shares (pandas.Series): Series with a date index. For each
-            day the value indicates the share of people who get vaccinated on
-            that day.
-        no_vaccination_share (float): Share of people who refuse to get
-            vaccinated.
-        init_start (pd.Timestamp): start date of the burn in period. On the
-            init_start all vaccinations that have been done until then are
-            handed out on that day.
+            column vaccination_rank. This column is a float with values between zero
+            and one. Low values mean that people get vaccinated early.
+        params (pandas.DataFrame): params DataFrame that contains a row labeled
+            ("vaccinations", "share_refuser", "adult").
+        seed (int): used after 2021-06-07.
+        vaccination_shares (pandas.Series): Series with a date index. For each day the
+            value indicates the share of people who get vaccinated on that day.
+        init_start (pd.Timestamp): start date of the burn in period. On the init_start
+            all vaccinations that have been done until then are handed out on that day.
 
     """
+    np.random.seed(seed)
     date = get_date(states)
-    no_vaccination_share = params.loc[
-        ("vaccinations", "share_refuser", "share_refuser"), "value"
+    no_vaccination_share_adult = params.loc[
+        ("vaccinations", "share_refuser", "adult"), "value"
     ]
 
     if not (vaccination_shares < 0.05).all():
@@ -47,18 +57,33 @@ def find_people_to_vaccinate(
             "If this was intended, simply ignore the warning.",
         )
 
-    cutoffs = vaccination_shares.sort_index().cumsum()
-    # set all cutoffs before the init_start to 0.
-    # that way on the init_start date everyone who should have been vaccinated
-    # until that day gets vaccinated.
-    cutoffs[: init_start - pd.Timedelta(days=1)] = 0
+    if date < pd.Timestamp("2021-07-15"):  # priorisation. only >= 16 get vaccinated.
+        cutoffs = vaccination_shares.sort_index().cumsum()
+        # set all cutoffs before the init_start to 0.
+        # that way on the init_start date everyone who should have been vaccinated
+        # until that day gets vaccinated.
+        cutoffs[: init_start - pd.Timedelta(days=1)] = 0
 
-    lower_candidate = cutoffs[date - pd.Timedelta(days=1)]
-    upper_candidate = cutoffs[date]
-    lower = min(lower_candidate, 1 - no_vaccination_share)
-    upper = min(upper_candidate, 1 - no_vaccination_share)
+        lower_candidate = cutoffs[date - pd.Timedelta(days=1)]
+        upper_candidate = cutoffs[date]
+        lower = min(lower_candidate, 1 - no_vaccination_share_adult)
+        upper = min(upper_candidate, 1 - no_vaccination_share_adult)
 
-    to_vaccinate = (lower <= states["vaccination_rank"]) & (
-        states["vaccination_rank"] < upper
-    )
+        to_vaccinate = (lower <= states["vaccination_rank"]) & (
+            states["vaccination_rank"] < upper
+        )
+    else:  # no priorisation. >= 12 get vaccinated
+        unvaccinated = ~states["ever_vaccinated"]
+        eligible = states["age"] >= 12
+
+        # the highest value denotes refusers
+        willing = (
+            states["vaccination_group_with_refuser_group"]
+            < states["vaccination_group_with_refuser_group"].max()
+        )
+        pool = states[unvaccinated & eligible & willing].index
+        n_to_draw = int(vaccination_shares[date] * len(states))
+        sampled = np.random.choice(pool, n_to_draw, replace=False)
+        to_vaccinate = pd.Series(states.index.isin(sampled), index=states.index)
+
     return to_vaccinate

--- a/tests/test_find_people_to_vaccinate.py
+++ b/tests/test_find_people_to_vaccinate.py
@@ -9,7 +9,10 @@ from src.policies.find_people_to_vaccinate import find_people_to_vaccinate
 @pytest.fixture
 def params():
     index = pd.MultiIndex.from_tuples(
-        [("vaccinations", "share_refuser", "share_refuser")]
+        [
+            ("vaccinations", "share_refuser", "adult"),
+            ("vaccinations", "share_refuser", "youth"),
+        ]
     )
     params = pd.DataFrame(
         data=0.0,
@@ -56,7 +59,7 @@ def test_find_people_to_vaccinate_with_refusers(params):
     states["vaccination_rank"] = [0.35, 0.45, 0.25, 0.15, 0.85, 0.55]
     states["date"] = pd.Timestamp("2021-02-03")
 
-    params["value"] = [0.3]
+    params["value"] = [0.3, 0.0]
 
     vaccination_shares = pd.Series(
         # 0.3 to 0.9 should get vaccinated, b/c of refusers only 0.3 to 0.7
@@ -116,6 +119,47 @@ def test_find_people_to_vaccinate_start_date(params):
             seed=33,
             vaccination_shares=vaccination_shares,
             init_start=pd.Timestamp("2021-02-03"),
+        )
+
+    pd.testing.assert_series_equal(expected, res, check_names=False)
+
+
+def test_find_people_to_vaccinate_after_june_7(params):
+    states = pd.DataFrame()
+    states["age"] = [30, 40, 50, 14, 10, 15]
+    states["vaccination_group_with_refuser_group"] = [1, 6, 4, 5, 5, 5]
+    states["ever_vaccinated"] = [True, False, False, False, False, True]
+    states["date"] = pd.Timestamp("2021-08-03")
+
+    params["value"] = [0.3, 0.0]
+
+    vaccination_shares = pd.Series(
+        [
+            0.1,
+            0.2,
+            0.35,  # 2 individuals should get vaccinated
+        ],
+        index=[
+            pd.Timestamp("2021-08-01"),
+            pd.Timestamp("2021-08-02"),
+            pd.Timestamp("2021-08-03"),
+        ],
+    )
+    # 0 and -1 already vaccinated -> must be False
+    # -2 is too young -> must be False
+    # 1 is a refuser -> must be False
+    expected = pd.Series([False, False, True, True, False, False])
+
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=UserWarning)
+
+        res = find_people_to_vaccinate(
+            receives_vaccine=None,
+            states=states,
+            params=params,
+            seed=33,  # result is dependent on the seed!
+            vaccination_shares=vaccination_shares,
+            init_start=pd.Timestamp("2021-01-15"),
         )
 
     pd.testing.assert_series_equal(expected, res, check_names=False)


### PR DESCRIPTION
- [x] Update the vaccination priority to allow different refuser shares for youths and adults
- [x] Update the vaccination policy to not require prioritization after mid June and vaccinate youths starting mid June. 